### PR TITLE
Add placeholder frontend views

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,7 +6,11 @@ import { RouterView, RouterLink } from 'vue-router'
   <div>
     <nav style="margin-bottom:20px;">
       <RouterLink to="/rooms" style="margin-right: 15px;">房间大厅</RouterLink>
-      <!-- 你可以继续加更多菜单，如注册、登录、个人中心等 -->
+      <RouterLink to="/login" style="margin-right: 15px;">登录</RouterLink>
+      <RouterLink to="/register" style="margin-right: 15px;">注册</RouterLink>
+      <RouterLink to="/user" style="margin-right: 15px;">个人中心</RouterLink>
+      <RouterLink to="/messages" style="margin-right: 15px;">消息</RouterLink>
+      <RouterLink to="/history" style="margin-right: 15px;">历史对局</RouterLink>
     </nav>
     <RouterView />
   </div>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,10 +1,22 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import RoomList from '../views/RoomList.vue'
+import Login from '../views/Login.vue'
+import Register from '../views/Register.vue'
+import UserProfile from '../views/UserProfile.vue'
+import Messages from '../views/Messages.vue'
+import History from '../views/History.vue'
+import GameRoom from '../views/GameRoom.vue'
 
 const routes = [
-  { path: '/', component: Home },        // 首页
-  { path: '/rooms', component: RoomList } // 房间大厅
+  { path: '/', component: Home },               // 首页
+  { path: '/login', component: Login },         // 登录
+  { path: '/register', component: Register },   // 注册
+  { path: '/rooms', component: RoomList },      // 房间大厅
+  { path: '/user', component: UserProfile },    // 个人信息
+  { path: '/messages', component: Messages },   // 消息系统
+  { path: '/history', component: History },     // 历史对局
+  { path: '/game/:id', component: GameRoom }    // 游戏房间
 ]
 
 const router = createRouter({

--- a/frontend/src/views/GameRoom.vue
+++ b/frontend/src/views/GameRoom.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h2>游戏房间 {{ $route.params.id }}</h2>
+    <!-- TODO: 展示房间详细信息以及游戏界面 -->
+    <p>游戏界面待实现</p>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/History.vue
+++ b/frontend/src/views/History.vue
@@ -1,0 +1,12 @@
+<template>
+  <el-card>
+    <template #header>
+      <span>历史对局</span>
+    </template>
+    <!-- TODO: 调用 /api/history 获取数据 -->
+    <p>这里将展示玩家历史对局信息</p>
+  </el-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,44 @@
+<template>
+  <el-card class="login-card">
+    <h2>用户登录</h2>
+    <el-form :model="form" @submit.prevent="onSubmit" label-width="80px">
+      <el-form-item label="用户名">
+        <el-input v-model="form.username" />
+      </el-form-item>
+      <el-form-item label="密码">
+        <el-input type="password" v-model="form.password" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" @click="onSubmit">登录</el-button>
+      </el-form-item>
+    </el-form>
+  </el-card>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+import axios from 'axios'
+
+const form = reactive({
+  username: '',
+  password: ''
+})
+
+async function onSubmit() {
+  // TODO: 接入 /api/login
+  console.log('login submit', form)
+  try {
+    const res = await axios.post('http://localhost:3000/api/login', form)
+    console.log(res.data)
+  } catch (e) {
+    console.error(e)
+  }
+}
+</script>
+
+<style scoped>
+.login-card {
+  max-width: 400px;
+  margin: 0 auto;
+}
+</style>

--- a/frontend/src/views/Messages.vue
+++ b/frontend/src/views/Messages.vue
@@ -1,0 +1,18 @@
+<template>
+  <el-tabs v-model="active">
+    <el-tab-pane label="收件箱" name="inbox">
+      <!-- TODO: 展示收件箱列表 -->
+      <p>这里显示收件箱内容</p>
+    </el-tab-pane>
+    <el-tab-pane label="发件箱" name="outbox">
+      <!-- TODO: 展示发件箱列表 -->
+      <p>这里显示发件箱内容</p>
+    </el-tab-pane>
+  </el-tabs>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const active = ref('inbox')
+</script>

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -1,0 +1,43 @@
+<template>
+  <el-card class="login-card">
+    <h2>用户注册</h2>
+    <el-form :model="form" @submit.prevent="onSubmit" label-width="80px">
+      <el-form-item label="用户名">
+        <el-input v-model="form.username" />
+      </el-form-item>
+      <el-form-item label="密码">
+        <el-input type="password" v-model="form.password" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" @click="onSubmit">注册</el-button>
+      </el-form-item>
+    </el-form>
+  </el-card>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+import axios from 'axios'
+
+const form = reactive({
+  username: '',
+  password: ''
+})
+
+async function onSubmit() {
+  // TODO: 接入 /api/register
+  try {
+    const res = await axios.post('http://localhost:3000/api/register', form)
+    console.log(res.data)
+  } catch (e) {
+    console.error(e)
+  }
+}
+</script>
+
+<style scoped>
+.login-card {
+  max-width: 400px;
+  margin: 0 auto;
+}
+</style>

--- a/frontend/src/views/UserProfile.vue
+++ b/frontend/src/views/UserProfile.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <el-card>
+      <template #header>
+        <span>个人信息</span>
+      </template>
+      <div v-if="user">
+        <p>用户名：{{ user.username }}</p>
+        <!-- 可扩展更多字段 -->
+      </div>
+      <div v-else>请先登录。</div>
+    </el-card>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+
+const user = ref(null)
+
+onMounted(async () => {
+  // TODO: 通过 /api/user/me 获取登录用户信息
+  try {
+    const res = await axios.get('http://localhost:3000/api/user/me', {
+      headers: {
+        Authorization: 'Bearer ' + localStorage.getItem('token')
+      }
+    })
+    if(res.data.code === 0){
+      user.value = res.data.data
+    }
+  } catch(e){
+    console.error(e)
+  }
+})
+</script>


### PR DESCRIPTION
## Summary
- create login, registration, profile, messages, history and game pages
- update router with new paths
- extend the navigation menu

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686b77650e288322a9cbc6a85bcba5a2