### PR TITLE
Implement room creation and join flow

### DIFF
--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -34,4 +34,35 @@ router.get('/rooms', async (req, res) => {
   res.json({ code: 0, msg: "ok", data: rooms });
 });
 
+// 创建房间
+router.post('/rooms', async (req, res) => {
+  const { gametype = 1, validnum = 10 } = req.body;
+  const max = await Room.max('groomid');
+  const groomid = (max || 0) + 1;
+  const gamenum = 10000 + groomid;
+
+  await Room.create({
+    groomid,
+    gamenum,
+    gametype,
+    gamestate: 0,
+    validnum,
+    alivenum: validnum,
+    deathnum: 0,
+    groomtype: 1,
+    groomstatus: 0,
+    starttime: Math.floor(Date.now() / 1000)
+  });
+
+  res.json({ code: 0, msg: '房间创建成功', data: { groomid } });
+});
+
+// 获取房间详情
+router.get('/game/:groomid', async (req, res) => {
+  const { groomid } = req.params;
+  const room = await Room.findOne({ where: { groomid } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  res.json({ code: 0, msg: 'ok', data: room });
+});
+
 module.exports = router;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,13 @@ import App from './App.vue'
 import router from './router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
+import axios from 'axios'
+
+axios.defaults.baseURL = 'http://localhost:3000/api'
+const token = localStorage.getItem('token')
+if (token) {
+  axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
+}
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/src/views/GameRoom.vue
+++ b/frontend/src/views/GameRoom.vue
@@ -1,10 +1,28 @@
 <template>
   <div>
-    <h2>游戏房间 {{ $route.params.id }}</h2>
-    <!-- TODO: 展示房间详细信息以及游戏界面 -->
-    <p>游戏界面待实现</p>
+    <h2>游戏房间 {{ route.params.id }}</h2>
+    <el-card v-if="room">
+      <p>房间号：{{ room.groomid }}</p>
+      <p>类型：{{ room.gametype }}</p>
+      <p>状态：{{ room.gamestate }}</p>
+      <p>人数：{{ room.alivenum }} / {{ room.validnum }}</p>
+    </el-card>
+    <p v-else>加载中...</p>
   </div>
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import axios from 'axios'
+
+const route = useRoute()
+const room = ref(null)
+
+onMounted(async () => {
+  const res = await axios.get(`/game/${route.params.id}`)
+  if (res.data.code === 0) {
+    room.value = res.data.data
+  }
+})
 </script>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -17,20 +17,29 @@
 
 <script setup>
 import { reactive } from 'vue'
+import { useRouter } from 'vue-router'
 import axios from 'axios'
+import { ElMessage } from 'element-plus'
 
 const form = reactive({
   username: '',
   password: ''
 })
+const router = useRouter()
 
 async function onSubmit() {
-  // TODO: 接入 /api/login
-  console.log('login submit', form)
   try {
-    const res = await axios.post('http://localhost:3000/api/login', form)
-    console.log(res.data)
+    const res = await axios.post('/login', form)
+    if (res.data.code === 0) {
+      localStorage.setItem('token', res.data.token)
+      axios.defaults.headers.common['Authorization'] = `Bearer ${res.data.token}`
+      ElMessage.success('登录成功')
+      router.push('/')
+    } else {
+      ElMessage.error(res.data.msg || '登录失败')
+    }
   } catch (e) {
+    ElMessage.error('网络错误')
     console.error(e)
   }
 }

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -17,19 +17,27 @@
 
 <script setup>
 import { reactive } from 'vue'
+import { useRouter } from 'vue-router'
 import axios from 'axios'
+import { ElMessage } from 'element-plus'
 
 const form = reactive({
   username: '',
   password: ''
 })
+const router = useRouter()
 
 async function onSubmit() {
-  // TODO: 接入 /api/register
   try {
-    const res = await axios.post('http://localhost:3000/api/register', form)
-    console.log(res.data)
+    const res = await axios.post('/register', form)
+    if (res.data.code === 0) {
+      ElMessage.success('注册成功')
+      router.push('/login')
+    } else {
+      ElMessage.error(res.data.msg || '注册失败')
+    }
   } catch (e) {
+    ElMessage.error('网络错误')
     console.error(e)
   }
 }

--- a/frontend/src/views/RoomList.vue
+++ b/frontend/src/views/RoomList.vue
@@ -3,6 +3,7 @@
     <el-card>
       <template #header>
         <span>房间大厅</span>
+        <el-button type="primary" class="create-btn" @click="dialogVisible=true">创建房间</el-button>
       </template>
       <el-table :data="rooms" stripe style="width: 100%">
         <el-table-column prop="groomid" label="房间号" width="100"/>
@@ -14,24 +15,63 @@
         <el-table-column prop="deathnum" label="死亡"/>
         <el-table-column>
           <template #default="scope">
-            <el-button size="small" type="primary">进入</el-button>
+            <el-button size="small" type="primary" @click="enterRoom(scope.row.groomid)">进入</el-button>
           </template>
         </el-table-column>
       </el-table>
     </el-card>
+
+    <el-dialog v-model="dialogVisible" title="创建房间">
+      <el-form :model="form">
+        <el-form-item label="类型">
+          <el-input v-model="form.gametype" />
+        </el-form-item>
+        <el-form-item label="人数">
+          <el-input v-model="form.validnum" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible=false">取消</el-button>
+        <el-button type="primary" @click="createRoom">创建</el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import axios from 'axios'
+import { ElMessage } from 'element-plus'
 
 const rooms = ref([])
+const dialogVisible = ref(false)
+const form = ref({ gametype: 1, validnum: 10 })
+const router = useRouter()
 
 onMounted(async () => {
-  const res = await axios.get('http://localhost:3000/api/rooms')
+  const res = await axios.get('/rooms')
   if(res.data.code === 0){
     rooms.value = res.data.data
   }
 })
+
+async function createRoom() {
+  const res = await axios.post('/rooms', form.value)
+  if (res.data.code === 0) {
+    ElMessage.success('房间创建成功')
+    dialogVisible.value = false
+    // 刷新房间列表
+    const list = await axios.get('/rooms')
+    if (list.data.code === 0) {
+      rooms.value = list.data.data
+    }
+  } else {
+    ElMessage.error(res.data.msg || '创建失败')
+  }
+}
+
+function enterRoom(id) {
+  router.push(`/game/${id}`)
+}
 </script>

--- a/frontend/src/views/UserProfile.vue
+++ b/frontend/src/views/UserProfile.vue
@@ -16,21 +16,20 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
+import { ElMessage } from 'element-plus'
 
 const user = ref(null)
 
 onMounted(async () => {
-  // TODO: 通过 /api/user/me 获取登录用户信息
   try {
-    const res = await axios.get('http://localhost:3000/api/user/me', {
-      headers: {
-        Authorization: 'Bearer ' + localStorage.getItem('token')
-      }
-    })
+    const res = await axios.get('/user/me')
     if(res.data.code === 0){
       user.value = res.data.data
+    } else {
+      ElMessage.error(res.data.msg || '获取失败')
     }
   } catch(e){
+    ElMessage.error('网络错误')
     console.error(e)
   }
 })


### PR DESCRIPTION
## Summary
- enable creation of rooms and provide room detail API
- configure axios base URL and authorization header
- implement create/join actions in `RoomList`
- fetch room info in `GameRoom`
- persist token on login and update register/profile pages

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686b79219500832294aaa79109edbf51