### PR TITLE
Implement JWT middleware and refresh tokens

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -4,3 +4,4 @@ DB_PASS=yiwang0w0
 DB_NAME=dts_game
 JWT_SECRET=233333
 PORT=3000
+REFRESH_SECRET=refresh_secret_key

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASS=yourpassword
+DB_NAME=dts_game
+JWT_SECRET=your_jwt_secret
+PORT=3000
+REFRESH_SECRET=your_refresh_secret

--- a/backend/app.js
+++ b/backend/app.js
@@ -20,9 +20,6 @@ sequelize.authenticate()
 // 健康检查
 app.get('/api/ping', (req, res) => res.send('pong'));
 
-// 用户注册/登录接口
-app.use('/api', userRouter);
-
 // TODO: 以后可以继续挂载其他路由，比如：
 // const roomRouter = require('./routes/room');
 // app.use('/api', roomRouter);

--- a/backend/middlewares/auth.js
+++ b/backend/middlewares/auth.js
@@ -1,0 +1,20 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) return res.status(401).json({ code: 1, msg: '未认证' });
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return res.status(401).json({ code: 1, msg: '未认证' });
+  }
+
+  const token = parts[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (err) {
+    return res.status(401).json({ code: 1, msg: 'token无效' });
+  }
+};

--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -2,6 +2,9 @@ const express = require('express');
 const router = express.Router();
 const { Op } = require('sequelize');
 const sequelize = require('../models/index');
+const auth = require('../middlewares/auth');
+
+router.use(auth);
 
 // 建房间表模型
 const { DataTypes } = require('sequelize');

--- a/backend/utils/tokenStore.js
+++ b/backend/utils/tokenStore.js
@@ -1,0 +1,13 @@
+const refreshTokens = new Set();
+
+module.exports = {
+  add(token) {
+    refreshTokens.add(token);
+  },
+  has(token) {
+    return refreshTokens.has(token);
+  },
+  remove(token) {
+    refreshTokens.delete(token);
+  }
+};


### PR DESCRIPTION
## Summary
- enforce JWT auth via middleware
- add token refresh and logout endpoints
- protect room routes with auth
- add `.env.example` and update secrets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b7abfbcb08322a9ba1343cd0f8b1c