### PR TITLE
Enhance auth and room routes

### DIFF
--- a/backend/middlewares/auth.js
+++ b/backend/middlewares/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function(req, res, next) {
+  const auth = req.headers['authorization'];
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return res.status(401).json({ code: 1, msg: '未授权' });
+  }
+  const token = auth.slice(7);
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (e) {
+    return res.status(401).json({ code: 1, msg: '无效token' });
+  }
+};

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -4,7 +4,8 @@ const sequelize = require('./index');
 const User = sequelize.define('bra_users', {
   uid: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
   username: { type: DataTypes.STRING(15), unique: true, allowNull: false, defaultValue: '' },
-  password: { type: DataTypes.STRING(100), allowNull: false, defaultValue: '' },
+  // bcrypt hash 长度固定为 60
+  password: { type: DataTypes.STRING(60), allowNull: false, defaultValue: '' },
   alt_pswd: { type: DataTypes.TINYINT.UNSIGNED, allowNull: false, defaultValue: 0 },
   ip: { type: DataTypes.STRING(15), allowNull: false, defaultValue: '' },
   groupid: { type: DataTypes.TINYINT.UNSIGNED, allowNull: false, defaultValue: 0 },

--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { Op } = require('sequelize');
 const sequelize = require('../models/index');
+const auth = require('../middlewares/auth');
 
 // 建房间表模型
 const { DataTypes } = require('sequelize');
@@ -57,12 +58,36 @@ router.post('/rooms', async (req, res) => {
   res.json({ code: 0, msg: '房间创建成功', data: { groomid } });
 });
 
+// 加入房间
+router.post('/rooms/:id/join', auth, async (req, res) => {
+  const groomid = req.params.id;
+  const room = await Room.findOne({ where: { groomid } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+
+  const User = require('../models/User');
+  const user = await User.findByPk(req.user.uid);
+  if (!user) return res.status(404).json({ code: 1, msg: '用户不存在' });
+  if (user.roomid > 0) {
+    return res.json({ code: 1, msg: '已在房间中' });
+  }
+  await user.update({ roomid: groomid });
+  res.json({ code: 0, msg: '加入房间成功' });
+});
+
 // 获取房间详情
 router.get('/game/:groomid', async (req, res) => {
   const { groomid } = req.params;
   const room = await Room.findOne({ where: { groomid } });
   if (!room) return res.json({ code: 1, msg: '房间不存在' });
   res.json({ code: 0, msg: 'ok', data: room });
+});
+
+// 游戏操作示例
+router.post('/game/:groomid/action', auth, async (req, res) => {
+  const { groomid } = req.params;
+  const { type, params } = req.body;
+  // 这里只是示例，实际逻辑需根据游戏规则实现
+  res.json({ code: 0, msg: '操作已接收', data: { groomid, type, params } });
 });
 
 module.exports = router;

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const User = require('../models/User');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const auth = require('../middlewares/auth');
 
 // 注册
 router.post('/register', async (req, res) => {
@@ -33,6 +34,15 @@ router.post('/login', async (req, res) => {
   const token = jwt.sign({ uid: user.uid, username: user.username }, process.env.JWT_SECRET, { expiresIn: '7d' });
 
   res.json({ code: 0, msg: "登录成功", token });
+});
+
+// 获取当前用户信息
+router.get('/user/me', auth, async (req, res) => {
+  const user = await User.findByPk(req.user.uid, {
+    attributes: { exclude: ['password'] }
+  });
+  if (!user) return res.status(404).json({ code: 1, msg: '用户不存在' });
+  res.json({ code: 0, msg: 'ok', data: user });
 });
 
 module.exports = router;

--- a/database.sql
+++ b/database.sql
@@ -74,7 +74,7 @@ DROP TABLE IF EXISTS `bra_users`;
 CREATE TABLE `bra_users` (
   `uid` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
   `username` char(15) NOT NULL DEFAULT '',
-  `password` char(32) NOT NULL DEFAULT '',
+  `password` char(60) NOT NULL DEFAULT '',
   `alt_pswd` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `ip` char(15) NOT NULL DEFAULT '',
   `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',


### PR DESCRIPTION
## Summary
- extend `bra_users.password` to store bcrypt hash
- document bcrypt length in `User` model
- add JWT auth middleware
- expose `/api/user/me` for current user info
- allow joining rooms and simple action endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b7ab43e34832285a330f8a1ede2b0