### PR TITLE
Add axios interceptors and dev proxy

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,12 +3,11 @@ import App from './App.vue'
 import router from './router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
-import axios from 'axios'
+import http from './utils/http'
 
-axios.defaults.baseURL = 'http://localhost:3000/api'
 const token = localStorage.getItem('token')
 if (token) {
-  axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
+  http.defaults.headers.common['Authorization'] = `Bearer ${token}`
 }
 
 const app = createApp(App)

--- a/frontend/src/utils/http.js
+++ b/frontend/src/utils/http.js
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+const http = axios.create({
+  baseURL: '/api'
+})
+
+http.interceptors.request.use(config => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+}, error => Promise.reject(error))
+
+http.interceptors.response.use(
+  response => response,
+  error => {
+    console.error('HTTP error', error)
+    return Promise.reject(error)
+  }
+)
+
+export default http

--- a/frontend/src/views/GameRoom.vue
+++ b/frontend/src/views/GameRoom.vue
@@ -14,13 +14,13 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import axios from 'axios'
+import http from '../utils/http'
 
 const route = useRoute()
 const room = ref(null)
 
 onMounted(async () => {
-  const res = await axios.get(`/game/${route.params.id}`)
+  const res = await http.get(`/game/${route.params.id}`)
   if (res.data.code === 0) {
     room.value = res.data.data
   }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -18,7 +18,7 @@
 <script setup>
 import { reactive } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import http from '../utils/http'
 import { ElMessage } from 'element-plus'
 
 const form = reactive({
@@ -29,10 +29,9 @@ const router = useRouter()
 
 async function onSubmit() {
   try {
-    const res = await axios.post('/login', form)
+    const res = await http.post('/login', form)
     if (res.data.code === 0) {
       localStorage.setItem('token', res.data.token)
-      axios.defaults.headers.common['Authorization'] = `Bearer ${res.data.token}`
       ElMessage.success('登录成功')
       router.push('/')
     } else {

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -18,7 +18,7 @@
 <script setup>
 import { reactive } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import http from '../utils/http'
 import { ElMessage } from 'element-plus'
 
 const form = reactive({
@@ -29,7 +29,7 @@ const router = useRouter()
 
 async function onSubmit() {
   try {
-    const res = await axios.post('/register', form)
+    const res = await http.post('/register', form)
     if (res.data.code === 0) {
       ElMessage.success('注册成功')
       router.push('/login')

--- a/frontend/src/views/RoomList.vue
+++ b/frontend/src/views/RoomList.vue
@@ -41,7 +41,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import http from '../utils/http'
 import { ElMessage } from 'element-plus'
 
 const rooms = ref([])
@@ -50,19 +50,19 @@ const form = ref({ gametype: 1, validnum: 10 })
 const router = useRouter()
 
 onMounted(async () => {
-  const res = await axios.get('/rooms')
+  const res = await http.get('/rooms')
   if(res.data.code === 0){
     rooms.value = res.data.data
   }
 })
 
 async function createRoom() {
-  const res = await axios.post('/rooms', form.value)
+  const res = await http.post('/rooms', form.value)
   if (res.data.code === 0) {
     ElMessage.success('房间创建成功')
     dialogVisible.value = false
     // 刷新房间列表
-    const list = await axios.get('/rooms')
+    const list = await http.get('/rooms')
     if (list.data.code === 0) {
       rooms.value = list.data.data
     }

--- a/frontend/src/views/UserProfile.vue
+++ b/frontend/src/views/UserProfile.vue
@@ -15,14 +15,14 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import axios from 'axios'
+import http from '../utils/http'
 import { ElMessage } from 'element-plus'
 
 const user = ref(null)
 
 onMounted(async () => {
   try {
-    const res = await axios.get('/user/me')
+    const res = await http.get('/user/me')
     if(res.data.code === 0){
       user.value = res.data.data
     } else {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,12 @@ import vue from '@vitejs/plugin-vue'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- create common axios instance with interceptors
- use the interceptor in all views
- update main entry to use shared axios instance
- configure Vite dev proxy for backend API

## Testing
- `npm run build` in frontend
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b7d59ce38832281721e678db28dcb