### PR TITLE
Update login flow on home

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,22 @@
 <script setup>
-import { RouterView, RouterLink } from 'vue-router'
+import { RouterView, RouterLink, useRouter } from 'vue-router'
+import { useAuthStore } from './stores/auth'
+const auth = useAuthStore()
+const router = useRouter()
+function logout() {
+  auth.logout()
+  router.push('/')
+}
 </script>
 
 <template>
   <div>
     <nav style="margin-bottom:20px;">
+      <RouterLink to="/" style="margin-right: 15px;">首页</RouterLink>
       <RouterLink to="/rooms" style="margin-right: 15px;">房间大厅</RouterLink>
-      <RouterLink to="/login" style="margin-right: 15px;">登录</RouterLink>
-      <RouterLink to="/register" style="margin-right: 15px;">注册</RouterLink>
+      <RouterLink v-if="!auth.isLoggedIn()" to="/login" style="margin-right: 15px;">登录</RouterLink>
+      <RouterLink v-if="!auth.isLoggedIn()" to="/register" style="margin-right: 15px;">注册</RouterLink>
+      <a v-else href="#" style="margin-right: 15px;" @click.prevent="logout">注销</a>
       <RouterLink to="/user" style="margin-right: 15px;">个人中心</RouterLink>
       <RouterLink to="/messages" style="margin-right: 15px;">消息</RouterLink>
       <RouterLink to="/history" style="margin-right: 15px;">历史对局</RouterLink>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,6 +4,7 @@ import router from './router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 import http from './utils/http'
+import { createPinia } from 'pinia'
 
 const token = localStorage.getItem('token')
 if (token) {
@@ -11,6 +12,8 @@ if (token) {
 }
 
 const app = createApp(App)
+const pinia = createPinia()
+app.use(pinia)
 app.use(router)
 app.use(ElementPlus)
 app.mount('#app')

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import http from '../utils/http'
+
+export const useAuthStore = defineStore('auth', () => {
+  const token = ref(localStorage.getItem('token') || '')
+  const refreshToken = ref(localStorage.getItem('refreshToken') || '')
+  const isLoggedIn = () => !!token.value
+
+  function setTokens(at, rt) {
+    token.value = at
+    refreshToken.value = rt
+    localStorage.setItem('token', at)
+    if (rt) localStorage.setItem('refreshToken', rt)
+    http.defaults.headers.common['Authorization'] = `Bearer ${at}`
+  }
+
+  function logout() {
+    if (refreshToken.value) {
+      http.post('/logout', { refreshToken: refreshToken.value }).catch(() => {})
+    }
+    token.value = ''
+    refreshToken.value = ''
+    localStorage.removeItem('token')
+    localStorage.removeItem('refreshToken')
+    delete http.defaults.headers.common['Authorization']
+  }
+
+  return { token, refreshToken, isLoggedIn, setTokens, logout }
+})

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -3,8 +3,52 @@
     <h1>欢迎来到DTS大逃杀游戏</h1>
     <p>请选择左侧菜单，或进入房间大厅。</p>
     <el-button type="primary" @click="$router.push('/rooms')">进入房间大厅</el-button>
+    <div v-if="!auth.isLoggedIn()" style="margin-top:20px;">
+      <el-form :model="form" @submit.prevent="onSubmit" label-width="80px">
+        <el-form-item label="用户名">
+          <el-input v-model="form.username" />
+        </el-form-item>
+        <el-form-item label="密码">
+          <el-input type="password" v-model="form.password" />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="onSubmit">登录</el-button>
+          <el-button type="success" @click="$router.push('/register')" style="margin-left:10px">注册</el-button>
+        </el-form-item>
+      </el-form>
+    </div>
+    <div v-else style="margin-top:20px;">
+      <el-button type="warning" @click="logout">注销</el-button>
+    </div>
   </el-card>
 </template>
 
 <script setup>
+import { reactive } from 'vue'
+import http from '../utils/http'
+import { ElMessage } from 'element-plus'
+import { useAuthStore } from '../stores/auth'
+
+const auth = useAuthStore()
+const form = reactive({ username: '', password: '' })
+
+async function onSubmit() {
+  try {
+    const res = await http.post('/login', form)
+    if (res.data.code === 0) {
+      auth.setTokens(res.data.accessToken, res.data.refreshToken)
+      ElMessage.success('登录成功')
+    } else {
+      ElMessage.error(res.data.msg || '登录失败')
+    }
+  } catch (e) {
+    ElMessage.error('网络错误')
+    console.error(e)
+  }
+}
+
+function logout() {
+  auth.logout()
+  ElMessage.success('已注销')
+}
 </script>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -10,6 +10,7 @@
       </el-form-item>
       <el-form-item>
         <el-button type="primary" @click="onSubmit">登录</el-button>
+        <el-button type="success" @click="router.push('/register')" style="margin-left:10px">注册</el-button>
       </el-form-item>
     </el-form>
   </el-card>
@@ -20,18 +21,20 @@ import { reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import http from '../utils/http'
 import { ElMessage } from 'element-plus'
+import { useAuthStore } from '../stores/auth'
 
 const form = reactive({
   username: '',
   password: ''
 })
 const router = useRouter()
+const auth = useAuthStore()
 
 async function onSubmit() {
   try {
     const res = await http.post('/login', form)
     if (res.data.code === 0) {
-      localStorage.setItem('token', res.data.token)
+      auth.setTokens(res.data.accessToken, res.data.refreshToken)
       ElMessage.success('登录成功')
       router.push('/')
     } else {


### PR DESCRIPTION
## Summary
- embed login form directly on the homepage
- implement auth store with Pinia
- show logout when user is logged in
- add register button inside login form
- update navigation with home link and logout

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b81fc22688322bdd450ff1296df9d