### PR TITLE
Improve user profile with editing

### DIFF
--- a/backend/middlewares/auth.js
+++ b/backend/middlewares/auth.js
@@ -1,9 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-module.exports = function(req, res, next) {
-const jwt = require('jsonwebtoken');
-
-module.exports = function(req, res, next) {
+module.exports = function (req, res, next) {
   const auth = req.headers['authorization'];
   if (!auth || !auth.startsWith('Bearer ')) {
     return res.status(401).json({ code: 1, msg: '未认证' });
@@ -17,6 +14,3 @@ module.exports = function(req, res, next) {
     return res.status(401).json({ code: 1, msg: 'token无效' });
   }
 };
-
-  }
-;

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -82,4 +82,18 @@ router.get('/user/me', auth, async (req, res) => {
   res.json({ code: 0, msg: 'ok', data: user });
 });
 
+// 更新当前用户信息
+router.put('/user/me', auth, async (req, res) => {
+  const { motto, gender, killmsg, lastword } = req.body;
+  const user = await User.findByPk(req.user.uid);
+  if (!user) return res.status(404).json({ code: 1, msg: '用户不存在' });
+  await user.update({
+    motto: motto ?? user.motto,
+    gender: gender ?? user.gender,
+    killmsg: killmsg ?? user.killmsg,
+    lastword: lastword ?? user.lastword,
+  });
+  res.json({ code: 0, msg: '更新成功' });
+});
+
 module.exports = router;

--- a/frontend/src/views/UserProfile.vue
+++ b/frontend/src/views/UserProfile.vue
@@ -5,8 +5,33 @@
         <span>个人信息</span>
       </template>
       <div v-if="user">
-        <p>用户名：{{ user.username }}</p>
-        <!-- 可扩展更多字段 -->
+        <el-form :model="editForm" label-width="80px">
+          <el-form-item label="用户名">
+            <el-input v-model="editForm.username" disabled />
+          </el-form-item>
+          <el-form-item label="性别">
+            <el-select v-model="editForm.gender" placeholder="请选择">
+              <el-option label="保密" value="0" />
+              <el-option label="男" value="M" />
+              <el-option label="女" value="F" />
+            </el-select>
+          </el-form-item>
+          <el-form-item label="格言">
+            <el-input v-model="editForm.motto" />
+          </el-form-item>
+          <el-form-item label="击杀宣言">
+            <el-input v-model="editForm.killmsg" />
+          </el-form-item>
+          <el-form-item label="遗言">
+            <el-input v-model="editForm.lastword" />
+          </el-form-item>
+          <el-form-item>
+            <el-button type="primary" @click="onSave">保存</el-button>
+          </el-form-item>
+        </el-form>
+        <p>胜场：{{ user.wingames }} / {{ user.validgames }} （胜率 {{ winRate }}）</p>
+        <p>ELO：{{ user.elo_rating }}</p>
+        <p>金币：{{ user.gold }}</p>
       </div>
       <div v-else>请先登录。</div>
     </el-card>
@@ -14,17 +39,37 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import http from '../utils/http'
 import { ElMessage } from 'element-plus'
 
 const user = ref(null)
+const editForm = reactive({
+  username: '',
+  motto: '',
+  killmsg: '',
+  lastword: '',
+  gender: ''
+})
 
-onMounted(async () => {
+const winRate = computed(() => {
+  if (!user.value) return '0%'
+  const valid = user.value.validgames || 0
+  return valid ? Math.round((user.value.wingames || 0) / valid * 100) + '%' : '0%'
+})
+
+async function fetchUser() {
   try {
     const res = await http.get('/user/me')
     if(res.data.code === 0){
       user.value = res.data.data
+      Object.assign(editForm, {
+        username: res.data.data.username,
+        motto: res.data.data.motto,
+        killmsg: res.data.data.killmsg,
+        lastword: res.data.data.lastword,
+        gender: res.data.data.gender
+      })
     } else {
       ElMessage.error(res.data.msg || '获取失败')
     }
@@ -32,5 +77,24 @@ onMounted(async () => {
     ElMessage.error('网络错误')
     console.error(e)
   }
-})
+}
+
+async function onSave() {
+  try {
+    const payload = { ...editForm }
+    delete payload.username
+    const res = await http.put('/user/me', payload)
+    if(res.data.code === 0){
+      ElMessage.success('更新成功')
+      await fetchUser()
+    } else {
+      ElMessage.error(res.data.msg || '更新失败')
+    }
+  } catch(e){
+    ElMessage.error('网络错误')
+    console.error(e)
+  }
+}
+
+onMounted(fetchUser)
 </script>


### PR DESCRIPTION
## Summary
- clean up auth middleware
- allow users to update profile info with new `PUT /api/user/me`
- expand UserProfile page to show and edit more fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b83783ae48322a3570747efc69cc4