### PR TITLE
Add API integration for messages and history views

### DIFF
--- a/frontend/src/views/History.vue
+++ b/frontend/src/views/History.vue
@@ -3,10 +3,48 @@
     <template #header>
       <span>历史对局</span>
     </template>
-    <!-- TODO: 调用 /api/history 获取数据 -->
-    <p>这里将展示玩家历史对局信息</p>
+    <el-table :data="list" stripe style="width: 100%">
+      <el-table-column prop="gid" label="局号" width="80" />
+      <el-table-column prop="winner" label="赢家" />
+      <el-table-column prop="gametype" label="类型" width="80" />
+      <el-table-column prop="gtime" label="时间">
+        <template #default="scope">
+          {{ formatTime(scope.row.gtime) }}
+        </template>
+      </el-table-column>
+    </el-table>
+    <el-pagination
+      style="margin-top: 10px; text-align: right"
+      :page-size="pageSize"
+      layout="prev, pager, next"
+      :total="total"
+      @current-change="page => loadHistory(page)"
+    />
   </el-card>
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import http from '../utils/http'
+
+const list = ref([])
+const total = ref(0)
+const pageSize = 10
+
+onMounted(() => {
+  loadHistory()
+})
+
+async function loadHistory(page = 1) {
+  const res = await http.get('/history', { params: { page, pageSize } })
+  if (res.data.code === 0) {
+    list.value = res.data.data.list
+    total.value = res.data.data.total
+  }
+}
+
+function formatTime(ts) {
+  const d = new Date(ts * 1000)
+  return d.toLocaleString()
+}
 </script>

--- a/frontend/src/views/Messages.vue
+++ b/frontend/src/views/Messages.vue
@@ -1,18 +1,71 @@
 <template>
-  <el-tabs v-model="active">
+  <el-tabs v-model="active" @tab-change="loadData()">
     <el-tab-pane label="收件箱" name="inbox">
-      <!-- TODO: 展示收件箱列表 -->
-      <p>这里显示收件箱内容</p>
+      <el-table :data="messages" stripe style="width: 100%">
+        <el-table-column prop="mid" label="ID" width="80" />
+        <el-table-column prop="sender" label="发送者" />
+        <el-table-column prop="title" label="标题" />
+        <el-table-column prop="timestamp" label="时间">
+          <template #default="scope">
+            {{ formatTime(scope.row.timestamp) }}
+          </template>
+        </el-table-column>
+      </el-table>
+      <el-pagination
+        style="margin-top: 10px; text-align: right"
+        :page-size="pageSize"
+        layout="prev, pager, next"
+        :total="total"
+        @current-change="page => loadData(page)"
+      />
     </el-tab-pane>
     <el-tab-pane label="发件箱" name="outbox">
-      <!-- TODO: 展示发件箱列表 -->
-      <p>这里显示发件箱内容</p>
+      <el-table :data="messages" stripe style="width: 100%">
+        <el-table-column prop="mid" label="ID" width="80" />
+        <el-table-column prop="receiver" label="接收者" />
+        <el-table-column prop="title" label="标题" />
+        <el-table-column prop="timestamp" label="时间">
+          <template #default="scope">
+            {{ formatTime(scope.row.timestamp) }}
+          </template>
+        </el-table-column>
+      </el-table>
+      <el-pagination
+        style="margin-top: 10px; text-align: right"
+        :page-size="pageSize"
+        layout="prev, pager, next"
+        :total="total"
+        @current-change="page => loadData(page)"
+      />
     </el-tab-pane>
   </el-tabs>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
+import http from '../utils/http'
 
 const active = ref('inbox')
+const messages = ref([])
+const total = ref(0)
+const pageSize = 10
+
+onMounted(() => {
+  loadData()
+})
+
+async function loadData(page = 1) {
+  const res = await http.get(`/messages/${active.value}`, {
+    params: { page, pageSize }
+  })
+  if (res.data.code === 0) {
+    messages.value = res.data.data.list
+    total.value = res.data.data.total
+  }
+}
+
+function formatTime(ts) {
+  const d = new Date(ts * 1000)
+  return d.toLocaleString()
+}
 </script>


### PR DESCRIPTION
## Summary
- connect Messages view with inbox/outbox endpoints
- show message tables with pagination
- fetch and display match history with pagination

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b8976eba883228b565c47eaebe7f4