### PR TITLE
Implement persistent refresh token store

### DIFF
--- a/backend/models/RefreshToken.js
+++ b/backend/models/RefreshToken.js
@@ -1,0 +1,13 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('./index');
+
+const RefreshToken = sequelize.define('refresh_tokens', {
+  id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+  token: { type: DataTypes.TEXT, allowNull: false },
+  expiresAt: { type: DataTypes.DATE }
+}, {
+  tableName: 'refresh_tokens',
+  timestamps: false
+});
+
+module.exports = RefreshToken;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -2,15 +2,20 @@
 const { Sequelize } = require('sequelize');
 require('dotenv').config();
 
-const sequelize = new Sequelize(
-  process.env.DB_NAME,
-  process.env.DB_USER,
-  process.env.DB_PASS,
-  {
-    host: process.env.DB_HOST,
-    dialect: 'mysql',
-    logging: false,
-  }
-);
+let sequelize;
+if (process.env.NODE_ENV === 'test') {
+  sequelize = new Sequelize('sqlite::memory:', { logging: false });
+} else {
+  sequelize = new Sequelize(
+    process.env.DB_NAME,
+    process.env.DB_USER,
+    process.env.DB_PASS,
+    {
+      host: process.env.DB_HOST,
+      dialect: 'mysql',
+      logging: false,
+    }
+  );
+}
 
 module.exports = sequelize;

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -42,7 +42,7 @@ router.post('/login', async (req, res) => {
     process.env.REFRESH_SECRET,
     { expiresIn: '7d' }
   );
-  tokenStore.add(refreshToken);
+  await tokenStore.add(refreshToken);
 
   res.json({ code: 0, msg: "登录成功", accessToken, refreshToken });
 });
@@ -51,7 +51,7 @@ router.post('/login', async (req, res) => {
 router.post('/refresh', async (req, res) => {
   const { refreshToken } = req.body;
   if (!refreshToken) return res.status(401).json({ code: 1, msg: '缺少参数' });
-  if (!tokenStore.has(refreshToken)) return res.status(403).json({ code: 1, msg: 'refresh token 无效' });
+  if (!await tokenStore.has(refreshToken)) return res.status(403).json({ code: 1, msg: 'refresh token 无效' });
 
   try {
     const payload = jwt.verify(refreshToken, process.env.REFRESH_SECRET);
@@ -73,9 +73,9 @@ router.post('/refresh', async (req, res) => {
 });
 
 // 注销
-router.post('/logout', (req, res) => {
+router.post('/logout', async (req, res) => {
   const { refreshToken } = req.body;
-  if (refreshToken) tokenStore.remove(refreshToken);
+  if (refreshToken) await tokenStore.remove(refreshToken);
   res.json({ code: 0, msg: '已登出' });
 });
 

--- a/backend/test/refreshToken.test.js
+++ b/backend/test/refreshToken.test.js
@@ -3,30 +3,33 @@ const request = require('supertest');
 const jwt = require('jsonwebtoken');
 const { expect } = require('chai');
 
+process.env.NODE_ENV = 'test';
+
 process.env.JWT_SECRET = 'testsecret';
 process.env.REFRESH_SECRET = 'refreshsecret';
 
 const userRouter = require('../routes/user');
 const tokenStore = require('../utils/tokenStore');
+const RefreshToken = require('../models/RefreshToken');
 
 const app = express();
 app.use(express.json());
 app.use('/', userRouter);
 
 describe('Refresh token', function() {
-  it('returns access token with uid and username', function(done) {
+  before(async function() {
+    await RefreshToken.sync({ force: true });
+  });
+
+  it('returns access token with uid and username', async function() {
     const refreshToken = jwt.sign({ uid: 1, username: 'foo' }, process.env.REFRESH_SECRET);
-    tokenStore.add(refreshToken);
-    request(app)
+    await tokenStore.add(refreshToken);
+    const res = await request(app)
       .post('/refresh')
       .send({ refreshToken })
-      .expect(200)
-      .end((err, res) => {
-        if (err) return done(err);
-        const payload = jwt.verify(res.body.accessToken, process.env.JWT_SECRET);
-        expect(payload.uid).to.equal(1);
-        expect(payload.username).to.equal('foo');
-        done();
-      });
+      .expect(200);
+    const payload = jwt.verify(res.body.accessToken, process.env.JWT_SECRET);
+    expect(payload.uid).to.equal(1);
+    expect(payload.username).to.equal('foo');
   });
 });

--- a/backend/utils/tokenStore.js
+++ b/backend/utils/tokenStore.js
@@ -1,13 +1,32 @@
-const refreshTokens = new Set();
+const jwt = require('jsonwebtoken');
+const { Op } = require('sequelize');
+const RefreshToken = require('../models/RefreshToken');
+
+async function cleanup() {
+  await RefreshToken.destroy({ where: { expiresAt: { [Op.lt]: new Date() } } });
+}
+
+setInterval(cleanup, 60 * 60 * 1000);
 
 module.exports = {
-  add(token) {
-    refreshTokens.add(token);
+  async add(token) {
+    const decoded = jwt.decode(token);
+    const expiresAt = decoded?.exp ? new Date(decoded.exp * 1000) : null;
+    await RefreshToken.create({ token, expiresAt });
+    await cleanup();
   },
-  has(token) {
-    return refreshTokens.has(token);
+  async has(token) {
+    await cleanup();
+    const record = await RefreshToken.findOne({ where: { token } });
+    if (!record) return false;
+    if (record.expiresAt && record.expiresAt < new Date()) {
+      await record.destroy();
+      return false;
+    }
+    return true;
   },
-  remove(token) {
-    refreshTokens.delete(token);
-  }
+  async remove(token) {
+    await RefreshToken.destroy({ where: { token } });
+  },
+  cleanup,
 };


### PR DESCRIPTION
## Summary
- add Sequelize model `RefreshToken`
- persist refresh tokens instead of using an in-memory set
- adapt login/refresh/logout routes to interact with DB
- use SQLite in tests and update refresh token test accordingly

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8c949f30832298493d220d1d6415