### PR TITLE
Fix refresh token uid handling

### DIFF
--- a/backend/models/RefreshToken.js
+++ b/backend/models/RefreshToken.js
@@ -3,6 +3,7 @@ const sequelize = require('./index');
 
 const RefreshToken = sequelize.define('refresh_tokens', {
   id: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true, autoIncrement: true },
+  uid: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false },
   token: { type: DataTypes.TEXT, allowNull: false },
   expiresAt: { type: DataTypes.DATE }
 }, {

--- a/backend/test/refreshToken.test.js
+++ b/backend/test/refreshToken.test.js
@@ -24,6 +24,8 @@ describe('Refresh token', function() {
   it('returns access token with uid and username', async function() {
     const refreshToken = jwt.sign({ uid: 1, username: 'foo' }, process.env.REFRESH_SECRET);
     await tokenStore.add(refreshToken);
+    const record = await RefreshToken.findOne({ where: { token: refreshToken } });
+    expect(record.uid).to.equal(1);
     const res = await request(app)
       .post('/refresh')
       .send({ refreshToken })

--- a/backend/utils/tokenStore.js
+++ b/backend/utils/tokenStore.js
@@ -12,7 +12,8 @@ module.exports = {
   async add(token) {
     const decoded = jwt.decode(token);
     const expiresAt = decoded?.exp ? new Date(decoded.exp * 1000) : null;
-    await RefreshToken.create({ token, expiresAt });
+    const uid = decoded?.uid;
+    await RefreshToken.create({ uid, token, expiresAt });
     await cleanup();
   },
   async has(token) {

--- a/database.sql
+++ b/database.sql
@@ -137,3 +137,12 @@ CREATE TABLE `bra_history` (
   INDEX `WMODE` (`wmode`),
   INDEX `WINNER` (`winner`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=COMPRESSED;
+
+DROP TABLE IF EXISTS `refresh_tokens`;
+CREATE TABLE `refresh_tokens` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `uid` int(10) unsigned NOT NULL,
+  `token` text NOT NULL,
+  `expiresAt` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- add missing `uid` column in refresh token model
- store `uid` when saving refresh tokens
- ensure refresh token tests check saved uid
- document `refresh_tokens` table in database schema

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b916631708322a245a70b413d99cf