### PR TITLE
Hide lobby links before login

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,8 +8,8 @@ const auth = useAuthStore()
   <div>
     <nav style="margin-bottom:20px;">
       <RouterLink to="/" style="margin-right: 15px;">首页</RouterLink>
-      <RouterLink to="/rooms" style="margin-right: 15px;">房间大厅</RouterLink>
-      <RouterLink to="/user" style="margin-right: 15px;">个人中心</RouterLink>
+      <RouterLink v-if="auth.isLoggedIn()" to="/rooms" style="margin-right: 15px;">房间大厅</RouterLink>
+      <RouterLink v-if="auth.isLoggedIn()" to="/user" style="margin-right: 15px;">个人中心</RouterLink>
       <RouterLink to="/messages" style="margin-right: 15px;">消息</RouterLink>
       <RouterLink to="/history" style="margin-right: 15px;">历史对局</RouterLink>
     </nav>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,8 +1,9 @@
 <template>
   <el-card>
     <h1>欢迎来到DTS大逃杀游戏</h1>
-    <p>请选择左侧菜单，或进入房间大厅。</p>
-    <el-button type="primary" @click="$router.push('/rooms')">进入房间大厅</el-button>
+    <p v-if="auth.isLoggedIn()">请选择左侧菜单，或进入房间大厅。</p>
+    <el-button v-if="auth.isLoggedIn()" type="primary" @click="$router.push('/rooms')">进入房间大厅</el-button>
+    <p v-else>登录后可进入房间大厅。</p>
     <div v-if="!auth.isLoggedIn()" style="margin-top:20px;">
       <el-form :model="form" @submit.prevent="onSubmit" label-width="80px">
         <el-form-item label="用户名">


### PR DESCRIPTION
## Summary
- hide room lobby and user lobby links in navigation when not logged in
- hide room lobby button on Home page until user logs in

## Testing
- `npm --prefix backend test` *(fails: Error: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_686c796a5eec832283dd7a0e3ac309f4