### PR TITLE
实现基础可游玩流程

### DIFF
--- a/backend/utils/npc.js
+++ b/backend/utils/npc.js
@@ -29,6 +29,17 @@ function act(game) {
     ][Math.floor(Math.random() * 4)];
     npc.pos[0] += dir[0];
     npc.pos[1] += dir[1];
+
+    if (game.players) {
+      for (const pid in game.players) {
+        const p = game.players[pid];
+        if (p.hp > 0 && p.pos && p.pos[0] === npc.pos[0] && p.pos[1] === npc.pos[1]) {
+          p.hp -= npc.atk;
+          if (!game.log) game.log = [];
+          game.log.push({ time: Date.now(), uid: Number(pid), type: 'hurt', dmg: npc.atk });
+        }
+      }
+    }
   }
   game.turn = (game.turn || 0) + 1;
 }


### PR DESCRIPTION
## Summary
- 加入房间时在 `gamevars` 中初始化玩家 hp/atk/pos
- `move` 和 `attack` 操作返回游戏状态与胜负信息
- NPC 行动时会攻击同坐标玩家
- 前端房间界面显示玩家 HP 并提供攻击按钮
- 游戏操作后同步玩家位置和血量，胜负时弹窗提示

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c913620e48322b9710440dfe6907f