### PR TITLE
实现房间自动启动定时任务

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,12 +1,11 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
-const sequelize = require('./models/index'); // 数据库连接
-const userRouter = require('./routes/user'); // 用户相关路由
+const sequelize = require('./models/index');
+const userRouter = require('./routes/user');
 const roomRouter = require('./routes/room');
 const messageRouter = require('./routes/message');
-const { scheduleRooms } = require('./utils/scheduler');
-
+const { createRoom } = require('./utils/scheduler');
 
 const app = express();
 
@@ -15,19 +14,14 @@ app.use(express.json());
 app.use('/api', userRouter);
 app.use('/api', roomRouter);
 app.use('/api', messageRouter);
-// 数据库连接测试
+
 sequelize.authenticate()
   .then(() => console.log('数据库连接成功！'))
   .catch(err => console.error('数据库连接失败：', err));
 
-scheduleRooms();
+createRoom();
 
-// 健康检查
 app.get('/api/ping', (req, res) => res.send('pong'));
-
-// TODO: 以后可以继续挂载其他路由，比如：
-// const roomRouter = require('./routes/room');
-// app.use('/api', roomRouter);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/models/History.js
+++ b/backend/models/History.js
@@ -1,0 +1,29 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('./index');
+
+const History = sequelize.define('bra_history', {
+  gid: { type: DataTypes.INTEGER.UNSIGNED, primaryKey: true },
+  wmode: { type: DataTypes.TINYINT.UNSIGNED, allowNull: false, defaultValue: 0 },
+  winner: { type: DataTypes.STRING(15), allowNull: false, defaultValue: '' },
+  motto: { type: DataTypes.STRING(30), allowNull: false, defaultValue: '' },
+  gametype: { type: DataTypes.TINYINT, allowNull: false, defaultValue: 0 },
+  vnum: { type: DataTypes.SMALLINT.UNSIGNED, allowNull: false, defaultValue: 0 },
+  gtime: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
+  gstime: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
+  getime: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
+  hdmg: { type: DataTypes.INTEGER.UNSIGNED, allowNull: false, defaultValue: 0 },
+  hdp: { type: DataTypes.STRING(15), allowNull: false, defaultValue: '' },
+  hkill: { type: DataTypes.SMALLINT.UNSIGNED, allowNull: false, defaultValue: 0 },
+  hkp: { type: DataTypes.STRING(15), allowNull: false, defaultValue: '' },
+  winnernum: { type: DataTypes.TINYINT, allowNull: false, defaultValue: 0 },
+  winnerteamID: { type: DataTypes.STRING(20), allowNull: false, defaultValue: '' },
+  winnerlist: { type: DataTypes.STRING(1000), allowNull: false, defaultValue: '' },
+  winnerpdata: { type: DataTypes.TEXT, allowNull: false, defaultValue: '' },
+  validlist: { type: DataTypes.TEXT, allowNull: false, defaultValue: '' },
+  hnews: { type: DataTypes.TEXT, allowNull: false, defaultValue: '' }
+}, {
+  tableName: 'bra_history',
+  timestamps: false
+});
+
+module.exports = History;

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -1,5 +1,5 @@
-const cron = require('node-cron');
 const Room = require('../models/Room');
+const History = require('../models/History');
 const config = require('../config/gameConfig');
 const npc = require('./npc');
 
@@ -14,7 +14,8 @@ async function createRoom() {
     turn: 0,
     npcs: npc.initNpcs()
   };
-  await Room.create({
+  const starttime = Math.floor(Date.now() / 1000) + config.readyMin * 60;
+  const room = await Room.create({
     groomid,
     gamenum,
     gametype: 1,
@@ -24,26 +25,40 @@ async function createRoom() {
     deathnum: 0,
     groomtype: 1,
     groomstatus: 0,
-    starttime: Math.floor(Date.now() / 1000),
+    starttime,
     gamevars: JSON.stringify(gamevars)
   });
+  setTimeout(() => startRoom(room.groomid), config.readyMin * 60 * 1000);
+  return room;
 }
 
-function scheduleRooms() {
-  if (!config.startMode) return;
-  let pattern;
-  if (config.startMode === 1) {
-    pattern = `${config.startMin} ${config.startHour} * * *`;
-  } else if (config.startMode === 2) {
-    const hour = config.startHour > 0 ? config.startHour : 1;
-    pattern = `0 */${hour} * * *`;
-  } else if (config.startMode === 3) {
-    const minute = config.startMin > 0 ? config.startMin : 1;
-    pattern = `*/${minute} * * * *`;
-  } else {
-    return;
+async function startRoom(groomid) {
+  const room = await Room.findOne({ where: { groomid } });
+  if (room && room.gamestate === 0) {
+    await room.update({ gamestate: 1, groomstatus: 40 });
   }
-  cron.schedule(pattern, createRoom);
 }
 
-module.exports = { scheduleRooms };
+async function endGame(room, result, winner) {
+  if (room.gamestate === 2) return; // already ended
+  await room.update({ gamestate: 2 });
+  const gid = room.gamenum;
+  await History.create({
+    gid,
+    wmode: result === 'win' ? 1 : 2,
+    winner: winner || '',
+    gametype: room.gametype,
+    vnum: room.validnum,
+    gtime: Math.floor(Date.now() / 1000),
+    gstime: room.starttime,
+    getime: Math.floor(Date.now() / 1000),
+    winnernum: result === 'win' ? 1 : 0,
+    winnerlist: winner || '',
+    winnerpdata: '',
+    validlist: '',
+    hnews: JSON.stringify(room.gamevars || '')
+  });
+  setTimeout(() => createRoom(), 60 * 1000);
+}
+
+module.exports = { createRoom, startRoom, endGame };


### PR DESCRIPTION
## Summary
- 在scheduler内部改为事件驱动，在游戏结束60秒后创建下一局房间
- 房间创建后按配置等待玩家准备时间再自动开始
- 归档上一局到`bra_history`
- 移除原先的cron定时器调用

## Testing
- `npm test` *(失败: 缺少 sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_686c930c567883229b9af82fbed283f4