### PR TITLE
Fix scheduler and DB model

### DIFF
--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -11,6 +11,11 @@ const Room = sequelize.define('bra_game', {
   deathnum: DataTypes.INTEGER.UNSIGNED,
   groomtype: DataTypes.INTEGER.UNSIGNED,
   groomstatus: DataTypes.INTEGER.UNSIGNED,
+  roomvars: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    defaultValue: ''
+  },
   starttime: DataTypes.INTEGER.UNSIGNED,
   gamevars: {
     type: DataTypes.TEXT,

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -1,3 +1,4 @@
+const cron = require('node-cron');
 const Room = require('../models/Room');
 const History = require('../models/History');
 const config = require('../config/gameConfig');
@@ -25,6 +26,7 @@ async function createRoom() {
     deathnum: 0,
     groomtype: 1,
     groomstatus: 0,
+    roomvars: JSON.stringify({}),
     starttime,
     gamevars: JSON.stringify(gamevars)
   });
@@ -61,4 +63,21 @@ async function endGame(room, result, winner) {
   setTimeout(() => createRoom(), 60 * 1000);
 }
 
-module.exports = { createRoom, startRoom, endGame };
+function scheduleRooms() {
+  if (!config.startMode) return;
+  let pattern;
+  if (config.startMode === 1) {
+    pattern = `${config.startMin} ${config.startHour} * * *`;
+  } else if (config.startMode === 2) {
+    const hour = config.startHour > 0 ? config.startHour : 1;
+    pattern = `0 */${hour} * * *`;
+  } else if (config.startMode === 3) {
+    const minute = config.startMin > 0 ? config.startMin : 1;
+    pattern = `*/${minute} * * * *`;
+  } else {
+    return;
+  }
+  cron.schedule(pattern, createRoom);
+}
+
+module.exports = { createRoom, startRoom, endGame, scheduleRooms };


### PR DESCRIPTION
## Summary
- add missing `scheduleRooms` in scheduler
- include `roomvars` field in `Room` model
- provide empty `roomvars` when creating rooms

## Testing
- `npm test` *(fails: Error: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_686ca6ea0588832294f763e73dc45adf