### PR TITLE
完善 NPC 行动逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ npm run dev
 以下列出了项目中常见的函数及其作用，方便快速了解代码：
 
 ### 后端工具函数
-- `initNpcs(count, mapSize)`：生成指定数量的 NPC【F:backend/utils/npc.js†L3-L18】
-- `act(game)`：驱动 NPC 行动并处理与玩家的交互【F:backend/utils/npc.js†L21-L45】
-- `createRoom()`：创建新的游戏房间【F:backend/utils/scheduler.js†L7-L35】
-- `startRoom(groomid)`：房间开始进入游戏阶段【F:backend/utils/scheduler.js†L37-L42】
-- `endGame(room, result, winner)`：结束游戏并保存历史【F:backend/utils/scheduler.js†L44-L64】
-- `scheduleRooms()`：按照配置定时创建房间【F:backend/utils/scheduler.js†L66-L81】
+- `initNpcs(count, mapSize)`：生成指定数量的 NPC【F:backend/utils/npc.js†L3-L26】
+- `act(game)`：驱动 NPC 行动并处理与玩家的交互【F:backend/utils/npc.js†L85-L119】
+- `createRoom()`：创建新的游戏房间【F:backend/utils/scheduler.js†L7-L39】
+- `startRoom(groomid)`：房间开始进入游戏阶段【F:backend/utils/scheduler.js†L41-L46】
+- `endGame(room, result, winner)`：结束游戏并保存历史【F:backend/utils/scheduler.js†L48-L68】
+- `scheduleRooms()`：按照配置定时创建房间【F:backend/utils/scheduler.js†L70-L84】
 - `add(token)`、`has(token)`、`remove(token)`：刷新令牌的增删查【F:backend/utils/tokenStore.js†L11-L33】
 
 ### 中间件

--- a/backend/utils/npc.js
+++ b/backend/utils/npc.js
@@ -1,43 +1,117 @@
 const npcData = require('../config/npcinfo.json');
 
-function initNpcs(count = 3, mapSize = 10) {
+function initNpcs(count = 3, mapSize = 10, blocked = []) {
   const npcs = [];
   for (let i = 0; i < count; i++) {
     const base = npcData[i % npcData.length];
+    let pos;
+    // 保证出生点不在封锁区域
+    do {
+      pos = [
+        Math.floor(Math.random() * mapSize),
+        Math.floor(Math.random() * mapSize)
+      ];
+    } while (blocked.some(b => b[0] === pos[0] && b[1] === pos[1]));
+
     npcs.push({
       id: i + 1,
       name: base.name,
       hp: base.hp,
       atk: base.atk,
-      pos: [
-        Math.floor(Math.random() * mapSize),
-        Math.floor(Math.random() * mapSize)
-      ]
+      pos,
+      alive: true
     });
   }
   return npcs;
 }
 
+function distance(a, b) {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+}
+
+function moveNpc(npc, targetPos, mapSize, blocked = []) {
+  const dirs = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1]
+  ];
+  // 简单追击：向距离最近的玩家移动一格
+  let bestDir = null;
+  let bestDist = Infinity;
+  for (const d of dirs) {
+    const nx = npc.pos[0] + d[0];
+    const ny = npc.pos[1] + d[1];
+    if (nx < 0 || ny < 0 || nx >= mapSize || ny >= mapSize) continue;
+    if (blocked.some(b => b[0] === nx && b[1] === ny)) continue;
+    const dist = distance([nx, ny], targetPos);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestDir = d;
+    }
+  }
+  if (bestDir) {
+    npc.pos[0] += bestDir[0];
+    npc.pos[1] += bestDir[1];
+    return true;
+  }
+  return false;
+}
+
+function attack(npc, player, log) {
+  const hit = Math.random() < 0.8; // 80% 命中率
+  if (hit) {
+    player.hp -= npc.atk;
+  }
+  log.push({
+    time: Date.now(),
+    type: 'npcAttack',
+    npc: npc.id,
+    target: player.id || player.uid,
+    hit,
+    dmg: hit ? npc.atk : 0
+  });
+  if (player.hp <= 0) {
+    player.hp = 0;
+    player.alive = false;
+    log.push({
+      time: Date.now(),
+      type: 'playerDead',
+      target: player.id || player.uid
+    });
+  }
+}
+
 function act(game) {
   if (!game.npcs) return;
+  const mapSize = game.mapSize || 10;
+  const blocked = game.blocked || [];
+  if (!game.log) game.log = [];
   for (const npc of game.npcs) {
-    const dir = [
-      [1, 0],
-      [-1, 0],
-      [0, 1],
-      [0, -1]
-    ][Math.floor(Math.random() * 4)];
-    npc.pos[0] += dir[0];
-    npc.pos[1] += dir[1];
-
-    if (game.players) {
-      for (const pid in game.players) {
-        const p = game.players[pid];
-        if (p.hp > 0 && p.pos && p.pos[0] === npc.pos[0] && p.pos[1] === npc.pos[1]) {
-          p.hp -= npc.atk;
-          if (!game.log) game.log = [];
-          game.log.push({ time: Date.now(), uid: Number(pid), type: 'hurt', dmg: npc.atk });
-        }
+    if (!npc.alive) continue;
+    const players = Object.values(game.players || {}).filter(p => p.hp > 0);
+    if (players.length === 0) break;
+    // 寻找最近的玩家
+    players.sort((a, b) => distance(npc.pos, a.pos) - distance(npc.pos, b.pos));
+    const target = players[0];
+    if (distance(npc.pos, target.pos) === 0) {
+      attack(npc, target, game.log);
+    } else {
+      moveNpc(npc, target.pos, mapSize, blocked);
+      game.log.push({ time: Date.now(), type: 'npcMove', npc: npc.id, pos: [...npc.pos] });
+      // 移动后若与玩家同格则进行攻击
+      if (distance(npc.pos, target.pos) === 0) {
+        attack(npc, target, game.log);
+      }
+    }
+  }
+  // 清理死亡的 NPC 和玩家
+  game.npcs = game.npcs.filter(n => n.alive);
+  if (game.players) {
+    for (const pid of Object.keys(game.players)) {
+      const pl = game.players[pid];
+      if (pl.hp !== undefined && pl.hp <= 0) {
+        pl.alive = false;
       }
     }
   }

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -8,12 +8,16 @@ async function createRoom() {
   const max = await Room.max('groomid');
   const groomid = (max || 0) + 1;
   const gamenum = 10000 + groomid;
+  const mapSize = 10;
+  const blocked = [];
   const gamevars = {
     players: {},
     map: [],
     log: [],
     turn: 0,
-    npcs: npc.initNpcs()
+    mapSize,
+    blocked,
+    npcs: npc.initNpcs(3, mapSize, blocked)
   };
   const starttime = Math.floor(Date.now() / 1000) + config.readyMin * 60;
   const room = await Room.create({


### PR DESCRIPTION
## Summary
- 增强 `backend/utils/npc.js`：加入追击及战斗判定，处理封锁区与地图边界
- 在 `scheduler.js` 初始化 NPC 时传入地图信息
- 更新 README 中函数行号引用

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb090818c83229fb2f2c8f582ad1d