### PR TITLE
Fix missing gameover module

### DIFF
--- a/backend/utils/gameover.js
+++ b/backend/utils/gameover.js
@@ -1,0 +1,20 @@
+const { checkEndConditions, endGame } = require('./scheduler');
+const logger = require('./logger');
+
+function checkGameOverAndEnd(game, room, logs = []) {
+  const result = checkEndConditions(game, room.gametype);
+  if (result) {
+    logs.push({
+      time: Date.now(),
+      type: 'gameover',
+      result: result.result,
+      winner: result.winner || ''
+    });
+    endGame(room, result.result, result.winner, game);
+    logger.addNews('gameover', result.winner || '', result.result);
+    return result.result;
+  }
+  return null;
+}
+
+module.exports = { checkGameOverAndEnd };


### PR DESCRIPTION
## Summary
- add `utils/gameover.js` to handle game over checks and finishing logic

## Testing
- `npm test` *(fails: Internal Server Error in some tests)*

------
https://chatgpt.com/codex/tasks/task_e_686cc307a2bc8322bf90c67f01bdb8a0