### PR TITLE
修复进入房间不刷新并加入搜索行动

### DIFF
--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -102,6 +102,11 @@ router.post('/game/:groomid/action', async (req, res) => {
   const room = await Room.findOne({ where: { groomid } });
   if (!room) return res.json({ code: 1, msg: '房间不存在' });
 
+  const supported = ['move', 'attack', 'search'];
+  if (!supported.includes(type)) {
+    return res.json({ code: 1, msg: '该操作暂未实现' });
+  }
+
   let game = {};
   try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
   if (!game.players) game.players = {};
@@ -121,6 +126,12 @@ router.post('/game/:groomid/action', async (req, res) => {
 
     game.log.push({ time: Date.now(), uid, type: 'move', pos: player.pos, msg: `${player.username}移动到(${player.pos[0]},${player.pos[1]})` });
     await logger.logSave(uid, 'move', `移动到(${player.pos[0]},${player.pos[1]})`);
+  }
+
+  if (type === 'search') {
+    const player = game.players[uid];
+    if (!player) return res.json({ code: 1, msg: '玩家不存在' });
+    game.log.push({ time: Date.now(), uid, type: 'search', msg: `${player.username}搜索了周围` });
   }
 
   if (type === 'attack') {

--- a/frontend/src/views/GameConfig.vue
+++ b/frontend/src/views/GameConfig.vue
@@ -18,16 +18,16 @@
 </template>
 
 <script setup>
-import { reactive } from 'vue'
+import { reactive, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 const route = useRoute()
 const router = useRouter()
-const roomId = route.params.id
+const roomId = computed(() => route.params.id)
 
 const form = reactive({ nickname: '', gender: 'm' })
 
 function startGame() {
-  router.push(`/room/${roomId}`)
+  router.push(`/room/${roomId.value}`)
 }
 </script>


### PR DESCRIPTION
## Summary
- 修复进入房间后页面不刷新，监听路由参数变化重新加载数据
- 增加待执行动作和"搜索"按钮，符合旧版DTS的操作流程
- GameConfig 页面同步修改为响应式 roomId
- 后端新增搜索指令并拒绝未实现的操作

## Testing
- `npm test` *(后端失败: mocha 未找到)*
- `npm test` *(前端缺少 test 脚本)*


------
https://chatgpt.com/codex/tasks/task_e_686cc8472c8c83228d8759be9e098988