### PR TITLE
修复convert脚本路径

### DIFF
--- a/backend/scripts/convertDTSData.js
+++ b/backend/scripts/convertDTSData.js
@@ -60,9 +60,9 @@ function parseMapItems(file) {
 
 function main() {
   if (!fs.existsSync('data')) fs.mkdirSync('data');
-  const mixinfo = parseVariable('../DTS/include/modules/base/itemmix/itemmix/config/itemmix.config.php', 'mixinfo');
+  const mixinfo = parseVariable('../../DTS-SAMPLE/include/modules/base/itemmix/itemmix/config/itemmix.config.php', 'mixinfo');
   fs.writeFileSync('data/itemmix.json', JSON.stringify(mixinfo, null, 2));
-  const mapitems = parseMapItems('../DTS/include/modules/base/itemmain/config/mapitem.config.php');
+  const mapitems = parseMapItems('../../DTS-SAMPLE/include/modules/base/itemmain/config/mapitem.config.php');
   fs.writeFileSync('data/mapitems.json', JSON.stringify(mapitems, null, 2));
   console.log('Converted', mixinfo.length, 'recipes and', mapitems.length, 'map items.');
 }


### PR DESCRIPTION
## Summary
- 修改 convertDTSData.js 读取路径，改为从 `DTS-SAMPLE` 目录加载配置

## Testing
- `node backend/scripts/convertDTSData.js`

------
https://chatgpt.com/codex/tasks/task_e_686ccd29a3bc8322a2fed406343fe512