### PR TITLE
Implement basic rest & item mix events

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ npm run dev
 - `endGame(room, result, winner)`：结束游戏并保存历史【F:backend/utils/scheduler.js†L48-L68】
 - `scheduleRooms()`：按照配置定时创建房间【F:backend/utils/scheduler.js†L70-L84】
 - `add(token)`、`has(token)`、`remove(token)`：刷新令牌的增删查【F:backend/utils/tokenStore.js†L11-L33】
+- `combineItems(player, items)`：基础道具合成逻辑【F:backend/utils/events.js†L6-L31】
+- `restPlayer(player, mode, log)`：睡眠/治疗等恢复效果【F:backend/utils/events.js†L33-L49】
 
 ### 中间件
 - `auth(req, res, next)`：JWT 鉴权中间件【F:backend/middlewares/auth.js†L3-L16】

--- a/backend/utils/events.js
+++ b/backend/utils/events.js
@@ -1,8 +1,55 @@
 // backend/utils/events.js
 
+// 部分事件逻辑由老版 DTS PHP 模块移植而来
+// 合成配方示例，仅用于演示
+const COMBINE_RECIPES = {
+  '草药+清水': { name: '治疗药水', hp: 20 },
+  '草药+草药': { name: '浓缩药水', hp: 40 },
+};
+
+function combineItems(player, items, log = []) {
+  if (!player.inventory) return false;
+  const names = items.map(i => i.name).sort();
+  const key = names.join('+');
+  const recipe = COMBINE_RECIPES[key];
+  if (!recipe) return false;
+
+  // 移除素材
+  for (const it of items) {
+    const idx = player.inventory.indexOf(it);
+    if (idx >= 0) player.inventory.splice(idx, 1);
+  }
+  // 生成新道具
+  player.inventory.push({ name: recipe.name, heal: recipe.hp });
+  log.push({
+    time: Date.now(),
+    type: 'itemmix',
+    uid: player.uid,
+    msg: `${player.username}合成了${recipe.name}`,
+  });
+  return true;
+}
+
+function restPlayer(player, mode = 'sleep', log = []) {
+  player.maxHp = player.maxHp || 20;
+  player.maxSp = player.maxSp || 10;
+  const now = Date.now();
+  if (mode === 'sleep') {
+    const spUp = Math.ceil(player.maxSp * 0.1);
+    player.sp = Math.min((player.sp || player.maxSp) + spUp, player.maxSp);
+    log.push({ time: now, type: 'rest', uid: player.uid, mode, msg: `${player.username}睡眠恢复了${spUp}点体力` });
+  } else if (mode === 'heal') {
+    const hpUp = Math.ceil(player.maxHp * 0.05);
+    player.hp = Math.min(player.hp + hpUp, player.maxHp);
+    log.push({ time: now, type: 'rest', uid: player.uid, mode, msg: `${player.username}治疗恢复了${hpUp}点生命` });
+  }
+}
+
 module.exports = {
   onPlayerMove: (player, game, room) => [],
   onPlayerAttackNpc: (player, npc, game, room) => [],
   onPlayerAttackPlayer: (player, target, game, room) => [],
   resolveStatus: (player, game, room, log) => {},
+  combineItems,
+  restPlayer,
 };


### PR DESCRIPTION
## Summary
- add simple item combine and rest logic in backend events module
- document the new events utilities in README

## Testing
- `npm test` *(fails: mocha not found / internal server error)*

------
https://chatgpt.com/codex/tasks/task_e_686cce5f0f4483229e7d0c06ae119867