### PR TITLE
实现按地图追踪NPC列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ npm run dev
 以下列出了项目中常见的函数及其作用，方便快速了解代码：
 
 ### 后端工具函数
-- `initNpcs(count, mapSize)`：生成指定数量的 NPC【F:backend/utils/npc.js†L3-L26】
-- `act(game)`：驱动 NPC 行动并处理与玩家的交互【F:backend/utils/npc.js†L85-L119】
-- `createRoom()`：创建新的游戏房间【F:backend/utils/scheduler.js†L7-L39】
-- `startRoom(groomid)`：房间开始进入游戏阶段【F:backend/utils/scheduler.js†L41-L46】
-- `endGame(room, result, winner)`：结束游戏并保存历史【F:backend/utils/scheduler.js†L48-L68】
-- `scheduleRooms()`：按照配置定时创建房间【F:backend/utils/scheduler.js†L70-L84】
+- `initNpcs(count, mapSize)`：生成指定数量的 NPC【F:backend/utils/npc.js†L3-L34】
+- `act(game)`：驱动 NPC 行动并处理与玩家的交互【F:backend/utils/npc.js†L93-L140】
+- `createRoom()`：创建新的游戏房间【F:backend/utils/scheduler.js†L16-L53】
+- `startRoom(groomid)`：房间开始进入游戏阶段【F:backend/utils/scheduler.js†L58-L64】
+- `endGame(room, result, winner)`：结束游戏并保存历史【F:backend/utils/scheduler.js†L93-L143】
+- `scheduleRooms()`：按照配置定时创建房间【F:backend/utils/scheduler.js†L148-L167】
 - `add(token)`、`has(token)`、`remove(token)`：刷新令牌的增删查【F:backend/utils/tokenStore.js†L11-L33】
 - `combineItems(player, items)`：基础道具合成逻辑【F:backend/utils/events.js†L6-L31】
 - `restPlayer(player, mode, log)`：睡眠/治疗等恢复效果【F:backend/utils/events.js†L33-L49】

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -19,6 +19,7 @@ async function createRoom(gametype = 1) {
   const gamenum = 10000 + groomid;
   const mapSize = 10;
   const blocked = [];
+  const { npcs, maps } = npc.initNpcs(3, mapSize, blocked);
   const gamevars = {
     players: {},
     map: [],
@@ -26,7 +27,8 @@ async function createRoom(gametype = 1) {
     turn: 0,
     mapSize,
     blocked,
-    npcs: npc.initNpcs(3, mapSize, blocked)
+    npcs,
+    mapNpcs: maps
   };
   const starttime = Math.floor(Date.now() / 1000) + config.readyMin * 60;
   const room = await Room.create({


### PR DESCRIPTION
## Summary
- NPC 初始化时按照随机地图归类
- NPC 行动后同步更新所在地图的 `npcs` 列表
- 房间创建逻辑保存按地图划分的 NPC
- 更新文档中相关代码行号

## Testing
- `npm --prefix backend test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd08d41ec832293f7dcc9093fbd91