### PR TITLE
更新房间创建逻辑和前端加入流程

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,10 @@
 - `GET /api/rooms`
 - 返回：房间数组（含状态、人数等）
 
-### 创建房间 （未实现）
+### 创建房间 （已实现）
 
 - `POST /api/rooms`
-- Body: `{ gametype, roomname, ... }`
+- Body: `{ gametype }`
 - 返回：房间信息
 
 ### 加入房间 （已实现）

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -57,12 +57,18 @@ function logout() {
 
 async function joinGame() {
   try {
+    let rid
     const next = await http.get('/rooms/next')
     if (next.data.code !== 0 || !next.data.data) {
-      ElMessage.error(next.data.msg || '未找到房间')
-      return
+      const created = await http.post('/rooms')
+      if (created.data.code !== 0 || !created.data.data) {
+        ElMessage.error(created.data.msg || '创建房间失败')
+        return
+      }
+      rid = created.data.data.groomid
+    } else {
+      rid = next.data.data.groomid
     }
-    const rid = next.data.data.groomid
     const join = await http.post(`/rooms/${rid}/join`)
     if (join.data.code === 0) {
       ElMessage.success('加入成功')


### PR DESCRIPTION
## Summary
- 新增普通房间创建接口 `POST /api/rooms`
- 房间列表过滤已结束的状态 99
- 首页加入游戏时无房间则自动创建
- 更新文档说明

## Testing
- `npm test` (backend) *(fails: mocha not found)*
- `npm test` (frontend) *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cde1f66fc83228d0244e4d99b79ed