### PR TITLE
实现历史对局查询接口

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -8,6 +8,7 @@ const roomRouter = require('./routes/room');
 const messageRouter = require('./routes/message');
 const adminRouter = require('./routes/admin');
 const logRouter = require('./routes/log');
+const historyRouter = require('./routes/history');
 const { scheduleRooms } = require('./utils/scheduler');
 const wsServer = require('./utils/socket');
 
@@ -22,6 +23,7 @@ app.use('/api', roomRouter);
 app.use('/api', messageRouter);
 app.use('/api', adminRouter);
 app.use('/api', logRouter);
+app.use('/api', historyRouter);
 
 // 数据库连接测试
 sequelize.authenticate()

--- a/backend/routes/history.js
+++ b/backend/routes/history.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const router = express.Router();
+const { Op } = require('sequelize');
+const auth = require('../middlewares/auth');
+const History = require('../models/History');
+
+router.use(auth);
+
+// 获取历史对局列表，可按 winner、gametype 等参数筛选
+router.get('/history', async (req, res) => {
+  const { winner, gametype, limit = 20 } = req.query;
+  const where = {};
+  if (winner) where.winner = winner;
+  if (gametype) where.gametype = Number(gametype);
+  try {
+    const list = await History.findAll({
+      where,
+      order: [['gid', 'DESC']],
+      limit: Number(limit) > 0 ? Number(limit) : 20
+    });
+    res.json({ code: 0, msg: 'ok', data: list });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ code: 1, msg: '服务器错误' });
+  }
+});
+
+// 获取指定局的详细信息
+router.get('/history/:gid', async (req, res) => {
+  const { gid } = req.params;
+  const record = await History.findOne({ where: { gid } });
+  if (!record) return res.status(404).json({ code: 1, msg: '记录不存在' });
+  res.json({ code: 0, msg: 'ok', data: record });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- 新增 `history` 路由，提供 `/api/history` 与 `/api/history/:gid` 两个接口
- `app.js` 注册该路由

## Testing
- `npm test` *(fails: AssertionError in gameRoom.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_686f1ea41c8083229eaa8194c9651740