### PR TITLE
Add configured flag for user setup

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -10,6 +10,7 @@ const User = sequelize.define('bra_users', {
   ip: { type: DataTypes.STRING(15), allowNull: false, defaultValue: '' },
   groupid: { type: DataTypes.TINYINT.UNSIGNED, allowNull: false, defaultValue: 0 },
   roomid: { type: DataTypes.TINYINT.UNSIGNED, allowNull: false, defaultValue: 0 },
+  configured: { type: DataTypes.TINYINT.UNSIGNED, allowNull: false, defaultValue: 0 },
   gender: { type: DataTypes.STRING(1), allowNull: false, defaultValue: '0' },
   motto: { type: DataTypes.STRING(30), allowNull: false, defaultValue: '' },
   killmsg: { type: DataTypes.STRING(30), allowNull: false, defaultValue: '' },

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -116,6 +116,7 @@ router.put('/user/me', auth, async (req, res) => {
     gender: gender ?? user.gender,
     killmsg: killmsg ?? user.killmsg,
     lastword: lastword ?? user.lastword,
+    configured: 1,
   });
   res.json({ code: 0, msg: '更新成功' });
 });

--- a/database.sql
+++ b/database.sql
@@ -79,6 +79,7 @@ CREATE TABLE `bra_users` (
   `ip` char(15) NOT NULL DEFAULT '',
   `groupid` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `roomid` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `configured` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `gender` char(1) NOT NULL DEFAULT '0',
   `motto` char(30) NOT NULL DEFAULT '',
   `killmsg` char(30) NOT NULL DEFAULT '',


### PR DESCRIPTION
## Summary
- extend `bra_users` table with `configured` flag
- support new field in Sequelize model
- mark user configured after updating profile

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f32b8cb7083229afe42c1f17df8ff