### PR TITLE
实现加入游戏时根据用户配置跳转

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -72,7 +72,16 @@ async function joinGame() {
     const join = await http.post(`/rooms/${rid}/join`)
     if (join.data.code === 0) {
       ElMessage.success('加入成功')
-      router.push(`/game-config/${rid}`)
+      const me = await http.get('/user/me')
+      if (me.data.code === 0 && me.data.data) {
+        if (me.data.data.configured === 0) {
+          router.push(`/game-config/${rid}`)
+        } else {
+          router.push(`/room/${rid}`)
+        }
+      } else {
+        router.push(`/game-config/${rid}`)
+      }
     } else {
       ElMessage.error(join.data.msg || '加入失败')
     }


### PR DESCRIPTION
## Summary
- 加入游戏后调用 `/user/me` 获取用户信息
- 根据 `configured` 字段判断跳转至配置页或房间

## Testing
- `npm test` *(failed: mocha not found / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_686f367a0a248322bf04f570f6211d71