### PR TITLE
更新房间日志显示逻辑

### DIFF
--- a/frontend/src/views/Room.vue
+++ b/frontend/src/views/Room.vue
@@ -79,7 +79,7 @@
       </el-card>
 
       <el-card v-if="log.length" class="mt-2">
-        <p v-for="(item, idx) in log" :key="idx">{{ item }}</p>
+        <p v-for="(item, idx) in log" :key="idx">{{ item.msg || item }}</p>
       </el-card>
     </div>
   </div>
@@ -167,6 +167,11 @@ async function loadData() {
     if (res.data.code === 0) {
       room.value = res.data.data
       if (res.data.data.inventory) inventory.value = res.data.data.inventory
+      if (res.data.data.game && Array.isArray(res.data.data.game.log)) {
+        log.value = log.value.concat(res.data.data.game.log)
+      } else if (res.data.data.gamevars && Array.isArray(res.data.data.gamevars.log)) {
+        log.value = log.value.concat(res.data.data.gamevars.log)
+      }
       const me = await http.get('/user/me')
       if (me.data.code === 0) {
         uid.value = me.data.data.uid
@@ -268,6 +273,9 @@ async function sendAction(type, params = {}) {
       log.value.push(`${type} 操作成功`)
       if (res.data.data) {
         const gameInfo = res.data.data.game || res.data.data
+        if (gameInfo.log && Array.isArray(gameInfo.log)) {
+          log.value = log.value.concat(gameInfo.log)
+        }
         if (gameInfo.players) {
           if (!uid.value) {
             const me = await http.get('/user/me')


### PR DESCRIPTION
## Summary
- 加载房间详情时同步後端返回的 `game.log`
- 操作成功後合并最新戰報到本地記錄
- 渲染日誌時僅顯示 `msg` 內容

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f663d48a8832282efd588a379e6c1