### PR TITLE
同步游戏玩家状态

### DIFF
--- a/frontend/src/views/Room.vue
+++ b/frontend/src/views/Room.vue
@@ -184,15 +184,21 @@ async function loadData() {
           }
         }
         if (res.data.data.gamevars && res.data.data.gamevars.players && res.data.data.gamevars.players[uid.value]) {
-          hp.value = res.data.data.gamevars.players[uid.value].hp
-          if (res.data.data.gamevars.players[uid.value].pos) {
-            pos.value = res.data.data.gamevars.players[uid.value].pos
+          const p = res.data.data.gamevars.players[uid.value]
+          hp.value = p.hp
+          if (p.pos) {
+            pos.value = p.pos
           }
-          if (res.data.data.gamevars.players[uid.value].map !== undefined) {
-            currentMap.value = res.data.data.gamevars.players[uid.value].map
-          } else if (res.data.data.gamevars.players[uid.value].pos) {
-            currentMap.value = res.data.data.gamevars.players[uid.value].pos[0]
+          if (p.map !== undefined) {
+            currentMap.value = p.map
+          } else if (p.pos) {
+            currentMap.value = p.pos[0]
           }
+          if (Array.isArray(p.inventory)) {
+            inventory.value = p.inventory
+          }
+        } else {
+          ElMessage.warning('玩家未加入成功，请重新加入房间')
         }
       }
       ws.joinRoom(roomId.value, { uid: uid.value })
@@ -301,6 +307,11 @@ async function sendAction(type, params = {}) {
             } else if (p.pos) {
               currentMap.value = p.pos[0]
             }
+            if (Array.isArray(p.inventory)) {
+              inventory.value = p.inventory
+            }
+          } else {
+            ElMessage.warning('玩家未加入成功，请重新加入房间')
           }
         }
         if (res.data.data.gameover) {


### PR DESCRIPTION
## Summary
- 更新 `loadData` 和 `sendAction` 逻辑，若 `gamevars.players[uid]` 存在则同步 hp、map、inventory
- 若玩家数据不存在则弹出提示重新加入房间

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f690dcb4c8322abb1a415733adfdb