### PR TITLE
实现加入房间返回玩家数据

### DIFF
--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -95,6 +95,7 @@ router.post('/rooms/:id/join', async (req, res) => {
     };
   }
   await room.update({ gamevars: JSON.stringify(game) });
+  await room.reload();
 
   // WebSocket: 房间内广播玩家加入
   emitRoomUpdate(groomid, { game });
@@ -103,7 +104,7 @@ router.post('/rooms/:id/join', async (req, res) => {
   // 再次写入用户房间号，确保数据库保持最新状态
   await user.update({ roomid: groomid });
 
-  res.json({ code: 0, msg: '加入房间成功' });
+  res.json({ code: 0, msg: '加入房间成功', data: { player: game.players[user.uid] } });
 });
 
 /**

--- a/backend/test/gameRoom.test.js
+++ b/backend/test/gameRoom.test.js
@@ -40,6 +40,21 @@ describe('房间与NPC相关逻辑', function() {
     expect(game.npcs).to.have.length.above(0);
   });
 
+  it('玩家加入后应写入gamevars且初始hp为20', async function() {
+    const user = await User.create({ username: 'joiner', password: 'x' });
+    const token = jwt.sign({ uid: user.uid, username: user.username }, process.env.JWT_SECRET);
+    const room = await createRoom();
+    await request(app)
+      .post(`/rooms/${room.groomid}/join`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const record = await Room.findByPk(room.groomid);
+    const game = JSON.parse(record.gamevars);
+    expect(game.players[user.uid]).to.exist;
+    expect(game.players[user.uid].hp).to.equal(20);
+  });
+
   it('玩家移动后NPC会行动并造成伤害与日志记录', async function() {
     const user = await User.create({ username: 'p1', password: 'h' });
     const token = jwt.sign({ uid: user.uid, username: user.username }, process.env.JWT_SECRET);

--- a/frontend/src/views/Room.vue
+++ b/frontend/src/views/Room.vue
@@ -183,15 +183,23 @@ async function loadData() {
             router.push('/')
             return
           }
-          const newGame = await http.get(`/game/${roomId.value}`)
-          if (newGame.data.code === 0) {
-            room.value = newGame.data.data
-            res = newGame
-            if (newGame.data.data.inventory) inventory.value = newGame.data.data.inventory
-            if (newGame.data.data.game && Array.isArray(newGame.data.data.game.log)) {
-              log.value = log.value.concat(newGame.data.data.game.log)
-            } else if (newGame.data.data.gamevars && Array.isArray(newGame.data.data.gamevars.log)) {
-              log.value = log.value.concat(newGame.data.data.gamevars.log)
+          if (joinRes.data.data && joinRes.data.data.player) {
+            const p = joinRes.data.data.player
+            hp.value = p.hp
+            pos.value = p.pos || pos.value
+            if (p.map !== undefined) {
+              currentMap.value = p.map
+            } else if (p.pos) {
+              currentMap.value = p.pos[0]
+            }
+            if (Array.isArray(p.inventory)) {
+              inventory.value = p.inventory
+            }
+            if (room.value && room.value.gamevars && room.value.gamevars.players) {
+              room.value.gamevars.players[uid.value] = p
+            }
+            if (res.data.data && res.data.data.gamevars && res.data.data.gamevars.players) {
+              res.data.data.gamevars.players[uid.value] = p
             }
           }
         }


### PR DESCRIPTION
## Summary
- 加入房间接口写入 `gamevars` 后重新加载房间并返回玩家数据
- Room.vue 调整加入逻辑，直接使用返回的玩家信息更新状态
- 新增单元测试确保加入后 `gamevars.players` 中有新玩家且 `hp` 为 20

## Testing
- `npm test` *(部分测试失败)*

------
https://chatgpt.com/codex/tasks/task_e_686f6f5bb490832281156daa52d2e471