### PR TITLE
Add admin map management

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -49,4 +49,144 @@ router.post('/admin/rooms/:id/end', async (req, res) => {
   res.json({ code: 0, msg: '房间已结束' });
 });
 
+// ========================
+// 地图与NPC管理
+// ========================
+
+// 获取房间的地图状态
+router.get('/admin/rooms/:id/maps', async (req, res) => {
+  const { id } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  res.json({
+    code: 0,
+    msg: 'ok',
+    data: {
+      map: game.map || {},
+      mapNpcs: game.mapNpcs || {},
+      mapProps: game.mapProps || {}
+    }
+  });
+});
+
+// 添加地图物品
+router.post('/admin/rooms/:id/maps/:mapId/items', async (req, res) => {
+  const { id, mapId } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.map) game.map = {};
+  if (!game.map[mapId]) game.map[mapId] = [];
+  const item = req.body || {};
+  game.map[mapId].push(item);
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: game.map[mapId] });
+});
+
+// 更新地图物品
+router.put('/admin/rooms/:id/maps/:mapId/items/:idx', async (req, res) => {
+  const { id, mapId, idx } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.map || !game.map[mapId] || !game.map[mapId][idx]) {
+    return res.json({ code: 1, msg: '物品不存在' });
+  }
+  game.map[mapId][idx] = Object.assign(game.map[mapId][idx], req.body || {});
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: game.map[mapId] });
+});
+
+// 删除地图物品
+router.delete('/admin/rooms/:id/maps/:mapId/items/:idx', async (req, res) => {
+  const { id, mapId, idx } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.map || !game.map[mapId] || !game.map[mapId][idx]) {
+    return res.json({ code: 1, msg: '物品不存在' });
+  }
+  game.map[mapId].splice(idx, 1);
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: game.map[mapId] });
+});
+
+// 添加NPC
+router.post('/admin/rooms/:id/maps/:mapId/npcs', async (req, res) => {
+  const { id, mapId } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.mapNpcs) game.mapNpcs = {};
+  if (!game.mapNpcs[mapId]) game.mapNpcs[mapId] = [];
+  const npc = req.body || {};
+  const all = Object.values(game.mapNpcs).flat();
+  const maxId = all.reduce((m, n) => Math.max(m, n.id || 0), 0);
+  npc.id = maxId + 1;
+  npc.map = parseInt(mapId, 10);
+  game.mapNpcs[mapId].push(npc);
+  game.npcs = Object.values(game.mapNpcs).flat();
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: game.mapNpcs[mapId] });
+});
+
+// 更新NPC
+router.put('/admin/rooms/:id/maps/:mapId/npcs/:nid', async (req, res) => {
+  const { id, mapId, nid } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.mapNpcs || !game.mapNpcs[mapId]) {
+    return res.json({ code: 1, msg: 'NPC不存在' });
+  }
+  const npc = game.mapNpcs[mapId].find(n => String(n.id) === String(nid));
+  if (!npc) return res.json({ code: 1, msg: 'NPC不存在' });
+  Object.assign(npc, req.body || {});
+  game.npcs = Object.values(game.mapNpcs).flat();
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: npc });
+});
+
+// 删除NPC
+router.delete('/admin/rooms/:id/maps/:mapId/npcs/:nid', async (req, res) => {
+  const { id, mapId, nid } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.mapNpcs || !game.mapNpcs[mapId]) {
+    return res.json({ code: 1, msg: 'NPC不存在' });
+  }
+  const idx = game.mapNpcs[mapId].findIndex(n => String(n.id) === String(nid));
+  if (idx === -1) return res.json({ code: 1, msg: 'NPC不存在' });
+  game.mapNpcs[mapId].splice(idx, 1);
+  game.npcs = Object.values(game.mapNpcs).flat();
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: game.mapNpcs[mapId] });
+});
+
+// 更新地图属性(禁区、天气)
+router.put('/admin/rooms/:id/maps/:mapId/settings', async (req, res) => {
+  const { id, mapId } = req.params;
+  const room = await Room.findOne({ where: { groomid: id } });
+  if (!room) return res.json({ code: 1, msg: '房间不存在' });
+  let game = {};
+  try { game = JSON.parse(room.gamevars || '{}'); } catch (e) {}
+  if (!game.mapProps) game.mapProps = {};
+  if (!game.mapProps[mapId]) game.mapProps[mapId] = { blocked: [], weather: '' };
+  const props = game.mapProps[mapId];
+  if (Array.isArray(req.body.blocked)) props.blocked = req.body.blocked;
+  if (typeof req.body.weather === 'string') props.weather = req.body.weather;
+  await room.update({ gamevars: JSON.stringify(game) });
+  res.json({ code: 0, msg: 'ok', data: props });
+});
+
 module.exports = router;
+

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -33,7 +33,8 @@ async function createRoom(gametype = 1) {
     mapSize,
     blocked,
     npcs,
-    mapNpcs: maps
+    mapNpcs: maps,
+    mapProps: {}
   };
   const starttime = Math.floor(Date.now() / 1000) + config.readyMin * 60;
   const room = await Room.create({

--- a/frontend/src/views/ManageGame.vue
+++ b/frontend/src/views/ManageGame.vue
@@ -13,18 +13,86 @@
         <el-table-column prop="groomid" label="房间ID" width="80" />
         <el-table-column prop="gamestate" label="状态" />
         <el-table-column prop="starttime" label="开始时间" />
+        <el-table-column label="管理">
+          <template #default="scope">
+            <el-button size="small" @click="manageRoom(scope.row.groomid)">管理</el-button>
+          </template>
+        </el-table-column>
       </el-table>
+
+      <div v-if="selectedRoom" style="margin-top:20px;">
+        <h3>房间 {{ selectedRoom }} 地图管理</h3>
+        <el-select v-model="currentMap" placeholder="选择地图" style="width:120px;">
+          <el-option v-for="(items,id) in mapsData.map" :key="id" :label="'地图'+id" :value="id" />
+        </el-select>
+
+        <div v-if="currentMap" style="margin-top:10px;">
+          <h4>物品</h4>
+          <el-table :data="mapsData.map[currentMap]" border>
+            <el-table-column prop="name" label="名称" />
+            <el-table-column width="80">
+              <template #default="scope">
+                <el-button size="small" type="danger" @click="removeItem(scope.$index)">删除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+          <div class="mb-2" style="margin-top:5px;">
+            <el-input v-model="newItem.name" placeholder="名称" style="width:120px; margin-right:5px;" />
+            <el-input v-model="newItem.kind" placeholder="类型" style="width:80px; margin-right:5px;" />
+            <el-input-number v-model="newItem.effect" :min="0" style="margin-right:5px;" />
+            <el-input-number v-model="newItem.amount" :min="1" style="margin-right:5px;" />
+            <el-button size="small" @click="addItem">添加</el-button>
+          </div>
+
+          <h4>NPC</h4>
+          <el-table :data="mapsData.mapNpcs[currentMap]" border>
+            <el-table-column prop="id" label="ID" width="60" />
+            <el-table-column prop="name" label="名称" />
+            <el-table-column width="80">
+              <template #default="scope">
+                <el-button size="small" type="danger" @click="removeNpc(scope.row.id)">删除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+          <div class="mb-2" style="margin-top:5px;">
+            <el-input v-model="newNpc.name" placeholder="名称" style="width:120px; margin-right:5px;" />
+            <el-input-number v-model="newNpc.hp" :min="1" style="margin-right:5px;" />
+            <el-input-number v-model="newNpc.atk" :min="0" style="margin-right:5px;" />
+            <el-button size="small" @click="addNpc">添加</el-button>
+          </div>
+
+          <h4>地图属性</h4>
+          <div>
+            <el-input v-model="weather" placeholder="天气" style="width:120px; margin-right:5px;" />
+            <el-input v-model="newBlock" placeholder="禁区 x,y" style="width:120px; margin-right:5px;" />
+            <el-button size="small" @click="addBlock">添加禁区</el-button>
+            <div style="margin-top:5px;">
+              <el-tag v-for="(b,i) in mapsData.mapProps[currentMap]?.blocked" :key="i" closable @close="removeBlock(i)" style="margin-right:5px;">
+                {{ b[0] }},{{ b[1] }}
+              </el-tag>
+            </div>
+            <el-button size="small" type="primary" style="margin-top:5px;" @click="saveProps">保存属性</el-button>
+          </div>
+        </div>
+      </div>
     </div>
   </el-card>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import http from '../utils/http'
 import { ElMessage } from 'element-plus'
 
 const rooms = ref([])
 const endId = ref('')
+const selectedRoom = ref(0)
+const mapsData = ref({ map: {}, mapNpcs: {}, mapProps: {} })
+const currentMap = ref('')
+const newItem = ref({ name: '', kind: '', effect: 0, amount: 1 })
+const newNpc = ref({ name: '', hp: 10, atk: 1 })
+const weather = ref('')
+const newBlock = ref('')
 
 async function fetchRooms() {
   const res = await http.get('/rooms')
@@ -62,6 +130,91 @@ async function endGame() {
     ElMessage.error('网络错误')
   }
 }
+
+async function manageRoom(id) {
+  selectedRoom.value = id
+  const res = await http.get(`/admin/rooms/${id}/maps`)
+  if (res.data.code === 0) {
+    mapsData.value = res.data.data
+    const first = Object.keys(mapsData.value.map)[0]
+    currentMap.value = first
+    updateWeather()
+  } else {
+    ElMessage.error(res.data.msg || '获取失败')
+  }
+}
+
+function updateWeather() {
+  if (mapsData.value.mapProps[currentMap.value]) {
+    weather.value = mapsData.value.mapProps[currentMap.value].weather || ''
+  } else {
+    weather.value = ''
+  }
+}
+
+async function addItem() {
+  if (!selectedRoom.value || !currentMap.value) return
+  const res = await http.post(`/admin/rooms/${selectedRoom.value}/maps/${currentMap.value}/items`, newItem.value)
+  if (res.data.code === 0) {
+    mapsData.value.map[currentMap.value] = res.data.data
+    newItem.value = { name: '', kind: '', effect: 0, amount: 1 }
+  }
+}
+
+async function removeItem(idx) {
+  const res = await http.delete(`/admin/rooms/${selectedRoom.value}/maps/${currentMap.value}/items/${idx}`)
+  if (res.data.code === 0) {
+    mapsData.value.map[currentMap.value] = res.data.data
+  }
+}
+
+async function addNpc() {
+  if (!selectedRoom.value || !currentMap.value) return
+  const res = await http.post(`/admin/rooms/${selectedRoom.value}/maps/${currentMap.value}/npcs`, newNpc.value)
+  if (res.data.code === 0) {
+    mapsData.value.mapNpcs[currentMap.value] = res.data.data
+    newNpc.value = { name: '', hp: 10, atk: 1 }
+  }
+}
+
+async function removeNpc(id) {
+  const res = await http.delete(`/admin/rooms/${selectedRoom.value}/maps/${currentMap.value}/npcs/${id}`)
+  if (res.data.code === 0) {
+    mapsData.value.mapNpcs[currentMap.value] = res.data.data
+  }
+}
+
+function addBlock() {
+  if (!mapsData.value.mapProps[currentMap.value]) {
+    mapsData.value.mapProps[currentMap.value] = { blocked: [], weather: '' }
+  }
+  const parts = newBlock.value.split(',')
+  if (parts.length === 2) {
+    const x = parseInt(parts[0])
+    const y = parseInt(parts[1])
+    if (!isNaN(x) && !isNaN(y)) {
+      mapsData.value.mapProps[currentMap.value].blocked.push([x, y])
+    }
+  }
+  newBlock.value = ''
+}
+
+function removeBlock(i) {
+  mapsData.value.mapProps[currentMap.value].blocked.splice(i, 1)
+}
+
+async function saveProps() {
+  const props = mapsData.value.mapProps[currentMap.value] || { blocked: [], weather: '' }
+  props.weather = weather.value
+  const res = await http.put(`/admin/rooms/${selectedRoom.value}/maps/${currentMap.value}/settings`, props)
+  if (res.data.code === 0) {
+    mapsData.value.mapProps[currentMap.value] = res.data.data
+    updateWeather()
+    ElMessage.success('已保存')
+  }
+}
+
+watch(currentMap, updateWeather)
 
 onMounted(fetchRooms)
 </script>


### PR DESCRIPTION
## Summary
- extend room scheduler gamevars to store `mapProps`
- add REST endpoints for map and NPC management
- implement frontend admin UI to manage map items, NPCs and map settings

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f739ac1448322af7c21c361b556b3