### PR TITLE
完善战斗事件与结算逻辑

### DIFF
--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -217,8 +217,8 @@ router.post('/game/:groomid/action', async (req, res) => {
     const player = game.players[uid];
     if (!player) return res.json({ code: 1, msg: '未加入房间' });
     player.pos = [params.x, params.y];
-    const mapId = params.map !== undefined ? params.map : params.x;
-    player.map = mapId;
+    const mapId = params.map !== undefined ? params.map : player.map;
+    if (mapId !== undefined) player.map = mapId;
 
     // 触发地图事件等
     const moveEvents = events.onPlayerMove(player, game, room) || [];

--- a/backend/test/npcGameover.test.js
+++ b/backend/test/npcGameover.test.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { expect } = require('chai');
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.READY_MIN = '0';
+
+const sequelize = require('../models');
+const Room = require('../models/Room');
+const User = require('../models/User');
+const roomRouter = require('../routes/room');
+const { createRoom } = require('../utils/scheduler');
+
+const app = express();
+app.use(express.json());
+app.use('/', roomRouter);
+
+describe('NPC 战斗胜利判定', function() {
+  before(async function() {
+    await sequelize.sync({ force: true });
+    global.setTimeout = fn => { fn(); return null; };
+    Math.random = () => 0;
+  });
+
+  it('击杀所有NPC后应立即gameover', async function() {
+    const user = await User.create({ username: 'hero', password: 'x' });
+    const token = jwt.sign({ uid: user.uid, username: user.username }, process.env.JWT_SECRET);
+    const room = await createRoom();
+    await request(app)
+      .post(`/rooms/${room.groomid}/join`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    let record = await Room.findByPk(room.groomid);
+    let game = JSON.parse(record.gamevars);
+    game.players[user.uid].atk = 50;
+    await record.update({ gamevars: JSON.stringify(game) });
+
+    let res;
+    for (const id of [1,2,3]) {
+      res = await request(app)
+        .post(`/game/${room.groomid}/action`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ type: 'attack', params: { npcId: id } })
+        .expect(200);
+    }
+    expect(res.body.data.gameover).to.equal('win');
+  });
+});

--- a/backend/utils/events.js
+++ b/backend/utils/events.js
@@ -45,11 +45,113 @@ function restPlayer(player, mode = 'sleep', log = []) {
   }
 }
 
+// ======================
+// 基础事件处理
+// ======================
+
+function onPlayerMove(player, game, room) {
+  const log = [];
+  const mapId = player.map;
+  if (!game.mapNpcs) return log;
+  const npcs = game.mapNpcs[mapId] || [];
+  for (const n of npcs) {
+    if (!n.alive) continue;
+    const dist = Math.abs(n.pos[0] - player.pos[0]) + Math.abs(n.pos[1] - player.pos[1]);
+    if (dist <= 1) {
+      player.hp -= n.atk;
+      log.push({
+        time: Date.now(),
+        type: 'hurt',
+        uid: player.uid,
+        msg: `${player.username}受到${n.atk}点伤害`,
+      });
+      if (player.hp <= 0) {
+        player.hp = 0;
+        player.alive = false;
+        log.push({ time: Date.now(), type: 'dead', uid: player.uid, msg: `${player.username}被${n.name}击倒` });
+        break;
+      }
+    }
+  }
+  return log;
+}
+
+function onPlayerAttackNpc(player, npc, game, room) {
+  const log = [];
+  // 保证引用到 mapNpcs 中的对象
+  const list = (game.mapNpcs && game.mapNpcs[npc.map]) || [];
+  const realNpc = list.find(n => n.id === npc.id) || npc;
+  if (!realNpc.alive) return log;
+  const dmg = player.atk || 0;
+  realNpc.hp -= dmg;
+  log.push({
+    time: Date.now(),
+    type: 'attack',
+    uid: player.uid,
+    target: realNpc.id,
+    msg: `${player.username}攻击${realNpc.name}造成${dmg}点伤害`,
+  });
+  if (realNpc.hp <= 0) {
+    realNpc.hp = 0;
+    realNpc.alive = false;
+    player.kills = (player.kills || 0) + 1;
+    log.push({ time: Date.now(), type: 'npcDead', uid: player.uid, npc: realNpc.id, msg: `${realNpc.name}被击败` });
+    if (realNpc.inventory && realNpc.inventory.length) {
+      if (!game.map[realNpc.map]) game.map[realNpc.map] = [];
+      game.map[realNpc.map].push(...realNpc.inventory);
+      log.push({ time: Date.now(), type: 'npcDrop', npc: realNpc.id, items: realNpc.inventory.map(i => i.name).join(',') });
+    }
+    const idx = list.indexOf(realNpc);
+    if (idx >= 0) list.splice(idx, 1);
+    game.npcs = Object.values(game.mapNpcs).flat();
+  } else {
+    // 简单反击
+    player.hp -= realNpc.atk;
+    log.push({ time: Date.now(), type: 'hurt', uid: player.uid, msg: `${player.username}受到${realNpc.atk}点反击伤害` });
+    if (player.hp <= 0) {
+      player.hp = 0;
+      player.alive = false;
+      log.push({ time: Date.now(), type: 'dead', uid: player.uid, msg: `${player.username}被${realNpc.name}击倒` });
+    }
+  }
+  return log;
+}
+
+function onPlayerAttackPlayer(player, target, game, room) {
+  const log = [];
+  if (!target.alive) return log;
+  const dmg = Math.max(1, (player.atk || 0) - (target.def || 0));
+  target.hp -= dmg;
+  log.push({ time: Date.now(), type: 'pk', uid: player.uid, target: target.uid, msg: `${player.username}对${target.username}造成${dmg}点伤害` });
+  if (target.hp <= 0) {
+    target.hp = 0;
+    target.alive = false;
+    player.kills = (player.kills || 0) + 1;
+    log.push({ time: Date.now(), type: 'playerDead', uid: target.uid, msg: `${target.username}被${player.username}击倒` });
+  }
+  return log;
+}
+
+function resolveStatus(player, game, room, log) {
+  if (!player.status) return;
+  const now = Date.now();
+  if (player.status.poison && player.status.poison > 0) {
+    player.hp -= 1;
+    player.status.poison -= 1;
+    log.push({ time: now, type: 'hurt', uid: player.uid, msg: `${player.username}受到1点中毒伤害` });
+  }
+  if (player.hp <= 0) {
+    player.hp = 0;
+    player.alive = false;
+    log.push({ time: now, type: 'dead', uid: player.uid, msg: `${player.username}死亡` });
+  }
+}
+
 module.exports = {
-  onPlayerMove: (player, game, room) => [],
-  onPlayerAttackNpc: (player, npc, game, room) => [],
-  onPlayerAttackPlayer: (player, target, game, room) => [],
-  resolveStatus: (player, game, room, log) => {},
+  onPlayerMove,
+  onPlayerAttackNpc,
+  onPlayerAttackPlayer,
+  resolveStatus,
   combineItems,
   restPlayer,
 };

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -80,7 +80,7 @@ function checkEndConditions(game, gametype) {
     if (teams.size === 1) return { result: 'win', winner: `Team${[...teams][0]}` };
     return null;
   }
-  if (gametype === 2) {
+  if (gametype === 1 || gametype === 2) {
     if (!game.npcs || game.npcs.length === 0) {
       return { result: 'win', winner: alivePlayers.map(p => p.username).join(',') };
     }
@@ -145,7 +145,9 @@ async function endGame(room, result, winner, game = null) {
   }
 
   // --- 自动开新房间 ---
-  setTimeout(() => createRoom(), 60 * 1000);
+  if (process.env.NODE_ENV !== 'test') {
+    setTimeout(() => createRoom(), 60 * 1000);
+  }
 }
 
 // =====================


### PR DESCRIPTION
## Summary
- 实现 `events.js` 中的移动、攻击、状态处理逻辑
- 调整 `room.js` 中移动时地图处理
- 更新 `scheduler.js` 胜负判定及测试环境下的房间创建
- 新增测试 `npcGameover.test.js` 验证击败 NPC 后结束游戏

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f83d58a2c8322afa115479d3b702d