### PR TITLE
实现基础战斗事件逻辑

### DIFF
--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -216,12 +216,14 @@ router.post('/game/:groomid/action', async (req, res) => {
   if (type === 'move') {
     const player = game.players[uid];
     if (!player) return res.json({ code: 1, msg: '未加入房间' });
+    const oldPos = player.pos ? [...player.pos] : [0, 0];
+    const oldMap = player.map;
     player.pos = [params.x, params.y];
     const mapId = params.map !== undefined ? params.map : params.x;
     player.map = mapId;
 
     // 触发地图事件等
-    const moveEvents = events.onPlayerMove(player, game, room) || [];
+    const moveEvents = events.onPlayerMove(player, game, room, oldPos, oldMap) || [];
     game.log.push(...moveEvents);
 
     events.resolveStatus(player, game, room, game.log);

--- a/backend/test/killNpcEnd.test.js
+++ b/backend/test/killNpcEnd.test.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { expect } = require('chai');
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'testsecret';
+process.env.READY_MIN = '0';
+
+const sequelize = require('../models');
+const Room = require('../models/Room');
+const User = require('../models/User');
+const History = require('../models/History');
+const roomRouter = require('../routes/room');
+const { createRoom } = require('../utils/scheduler');
+
+const app = express();
+app.use(express.json());
+app.use('/', roomRouter);
+
+const originalRandom = Math.random;
+const originalSetTimeout = global.setTimeout;
+
+describe('击败NPC触发游戏结束', function() {
+  before(async function() {
+    Math.random = () => 0;
+    global.setTimeout = (fn) => { fn(); return null; };
+    await sequelize.sync({ force: true });
+  });
+
+  after(function() {
+    Math.random = originalRandom;
+    global.setTimeout = originalSetTimeout;
+  });
+
+  it('最后一个NPC被击败后应判定胜利', async function() {
+    const user = await User.create({ username: 'hero', password: 'h' });
+    const token = jwt.sign({ uid: user.uid, username: user.username }, process.env.JWT_SECRET);
+    const room = await createRoom(2); // PVE 模式
+    await request(app)
+      .post(`/rooms/${room.groomid}/join`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    // 只保留一个NPC
+    let record = await Room.findByPk(room.groomid);
+    let game = JSON.parse(record.gamevars);
+    game.npcs = game.npcs.slice(0,1);
+    game.mapNpcs = { 0: [game.npcs[0]] };
+    game.players[user.uid].atk = 50;
+    await record.update({ gamevars: JSON.stringify(game) });
+
+    const res = await request(app)
+      .post(`/game/${room.groomid}/action`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'attack', params: { npcId: game.npcs[0].id } })
+      .expect(200);
+
+    expect(res.body.data.gameover).to.equal('win');
+    const count = await History.count();
+    expect(count).to.equal(1);
+  });
+});

--- a/backend/utils/events.js
+++ b/backend/utils/events.js
@@ -45,11 +45,123 @@ function restPlayer(player, mode = 'sleep', log = []) {
   }
 }
 
+function distance(a, b) {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+}
+
+function onPlayerMove(player, game, room, oldPos = null, oldMap = null) {
+  const logs = [];
+  if (!game.npcs) return logs;
+  const prevPos = oldPos || player.pos;
+  const prevMap = oldMap !== null ? oldMap : player.map;
+  for (const n of game.npcs) {
+    if (!n.alive) continue;
+    if (n.map !== prevMap) continue;
+    if (distance(n.pos, prevPos) === 0 || distance(n.pos, player.pos) <= 1) {
+      player.hp -= n.atk;
+      logs.push({
+        time: Date.now(),
+        type: 'hurt',
+        uid: player.uid,
+        npc: n.id,
+        dmg: n.atk,
+        msg: `${n.name}攻击${player.username}造成${n.atk}点伤害`
+      });
+      if (player.hp <= 0) {
+        player.hp = 0;
+        player.alive = false;
+        logs.push({ time: Date.now(), type: 'playerDead', uid: player.uid });
+        break;
+      }
+    }
+  }
+  return logs;
+}
+
+function onPlayerAttackNpc(player, npc, game, room) {
+  const logs = [];
+  if (!npc.alive) return logs;
+  const dmg = Math.max(1, player.atk);
+  npc.hp -= dmg;
+  logs.push({
+    time: Date.now(),
+    type: 'attackNpc',
+    uid: player.uid,
+    npc: npc.id,
+    dmg,
+    msg: `${player.username}攻击${npc.name}造成${dmg}点伤害`
+  });
+  if (npc.hp <= 0) {
+    npc.alive = false;
+    npc.hp = 0;
+    logs.push({ time: Date.now(), type: 'npcDead', npc: npc.id, by: player.uid });
+    player.kills = (player.kills || 0) + 1;
+    if (game.map && game.map[npc.map]) {
+      const drop = require('./map').drawItem(game.map, npc.map);
+      if (drop) {
+        if (!player.inventory) player.inventory = [];
+        player.inventory.push(drop);
+        logs.push({ time: Date.now(), type: 'itemget', uid: player.uid, item: drop.name });
+      }
+    }
+    if (game.mapNpcs && game.mapNpcs[npc.map]) {
+      const idx = game.mapNpcs[npc.map].findIndex(n => n.id === npc.id);
+      if (idx >= 0) game.mapNpcs[npc.map].splice(idx, 1);
+    }
+    const i = game.npcs.indexOf(npc);
+    if (i >= 0) game.npcs.splice(i, 1);
+  }
+  return logs;
+}
+
+function onPlayerAttackPlayer(player, target, game, room) {
+  const logs = [];
+  if (!target.alive) return logs;
+  const dmg = Math.max(1, player.atk - (target.def || 0));
+  target.hp -= dmg;
+  logs.push({
+    time: Date.now(),
+    type: 'attackPlayer',
+    attacker: player.uid,
+    target: target.uid,
+    dmg,
+    msg: `${player.username}攻击${target.username}造成${dmg}点伤害`
+  });
+  if (target.hp <= 0) {
+    target.hp = 0;
+    target.alive = false;
+    player.kills = (player.kills || 0) + 1;
+    logs.push({ time: Date.now(), type: 'playerDead', uid: target.uid, by: player.uid });
+  }
+  return logs;
+}
+
+function resolveStatus(player, game, room, log) {
+  if (!player.status) return;
+  const now = Date.now();
+  if (player.status.poison) {
+    player.hp -= player.status.poison;
+    log.push({
+      time: now,
+      type: 'status',
+      status: 'poison',
+      uid: player.uid,
+      dmg: player.status.poison,
+      msg: `${player.username}受到毒素影响，损失${player.status.poison}点生命`
+    });
+    if (player.hp <= 0) {
+      player.hp = 0;
+      player.alive = false;
+      log.push({ time: now, type: 'playerDead', uid: player.uid });
+    }
+  }
+}
+
 module.exports = {
-  onPlayerMove: (player, game, room) => [],
-  onPlayerAttackNpc: (player, npc, game, room) => [],
-  onPlayerAttackPlayer: (player, target, game, room) => [],
-  resolveStatus: (player, game, room, log) => {},
+  onPlayerMove,
+  onPlayerAttackNpc,
+  onPlayerAttackPlayer,
+  resolveStatus,
   combineItems,
   restPlayer,
 };

--- a/backend/utils/scheduler.js
+++ b/backend/utils/scheduler.js
@@ -88,7 +88,12 @@ function checkEndConditions(game, gametype) {
     return null;
   }
   // 个人乱斗
-  if (alivePlayers.length === 1) return { result: 'win', winner: alivePlayers[0].username };
+  if (alivePlayers.length === 1) {
+    if (!game.npcs || game.npcs.length === 0) {
+      return { result: 'win', winner: alivePlayers[0].username };
+    }
+    return null;
+  }
   if (alivePlayers.length === 0) return { result: 'lose' };
   return null;
 }


### PR DESCRIPTION
## Summary
- 完成 `events.js` 中的移动、攻击和状态处理逻辑
- 更新 `scheduler` 胜负判定规则，避免单人立即胜利
- 调整房间路由以传递旧坐标供事件判断
- 新增单元测试 `killNpcEnd.test.js` 验证击败 NPC 后游戏结束

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f8622fcd483229ca0ec83ff156d33